### PR TITLE
Droni 48, 59 jpa 설정 및 유저 엔티티 매핑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.generated
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,13 @@ dependencies {
     // OpenAPI UI and codegen
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.52'
+
+    // jpa 설정
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // postgres driver
+    implementation group: 'org.postgresql', name:'postgresql', version: '42.7.3'
+
     // https://mvnrepository.com/artifact/org.hibernate/hibernate-validator
     implementation group: 'org.hibernate', name: 'hibernate-validator', version: '8.0.1.Final'
 
@@ -43,6 +50,7 @@ swaggerSources {
         inputFile = file("$rootDir/src/main/resources/openapi.yaml")
         code {
             language = 'spring'
+            outputDir = file("$rootDir/.generated")
             configFile = file("$rootDir/src/main/resources/codegenConfig.json")
             additionalProperties = [
                     "interfaceOnly":true,
@@ -57,8 +65,12 @@ swaggerSources {
 
 }
 compileJava.dependsOn(swaggerSources.droni.code)
-sourceSets.main.java.srcDir("${swaggerSources.droni.code.outputDir}/src/main/java")
-sourceSets.main.resources.srcDir("${swaggerSources.droni.code.outputDir}/src/main/resources")
-tasks.named('test') {
-    useJUnitPlatform()
+sourceSets {
+    main {
+        java.srcDir("${swaggerSources.droni.code.outputDir}/src/main/java")
+    }
+}
+
+clean.doFirst {
+  delete "${swaggerSources.droni.code.outputDir}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.4'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'org.hidetake.swagger.generator' version '2.19.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/droni/backend/droniuser/entity/DroniUser.java
+++ b/src/main/java/droni/backend/droniuser/entity/DroniUser.java
@@ -1,0 +1,37 @@
+package droni.backend.droniuser.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class DroniUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int userId;
+    private String phoneNumber;
+    private String email;
+    private String name;
+    private String profileImage;
+    private String nickname;
+    private String timeZone;
+    private String address;
+    private String addressDetail;
+    private String refreshToken;
+    private boolean notificationEnabled;
+    private boolean marketingEnabled;
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,35 @@
+spring:
+  profiles:
+    group:
+      "local": "default,local"
+      "dev": "default,dev"
+      "rel": "default, rel"
+      "prod": "default,prod"
+---
+spring:
+  config:
+    activate:
+      on-profile: default
+  application:
+    name: droni-backend-api
+  datasource:
+    url: jdbc:postgresql://${droni.postgresql.ip}:${droni.postgresql.port}/${droni.postgresql.database}
+    username: droniadmin
+    password: droni
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      max-lifetime: 50000
+      maximum-pool-size: 10
+  jpa:
+    show-sql: false
+    open-in-view: true
+    database: postgresql
+    properties:
+      hibernate:
+        format_sql: true
+server:
+  port: 8080
+# OpenAPI sprigDOC configuration
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
@@ -7,3 +39,18 @@ springdoc:
     display-request-duration: true
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    hibernate:
+      ddl-auto: none
+droni:
+  postgresql:
+    ip: localhost
+    port: 5432
+    database: droni
+


### PR DESCRIPTION
[https://kakao-mygod456.atlassian.net/browse/DRONI-48?atlOrigin=eyJpIjoiYzU5ZmM0Y2FjNjYxNGE0MWI1ZDdlOTRjYjVhMzJmMDAiLCJwIjoiaiJ9]

swagger code gen outputDir 작성
generated dir gitignore 추가
gradle version 8.3 -> 8.5 변경
jpa, hikariCP application.yaml 설정
application.yaml profile 설정



[https://kakao-mygod456.atlassian.net/browse/DRONI-59?atlOrigin=eyJpIjoiMTY1N2MxMDRhNGVlNGFlNmI1YzVmY2IzYmEwODVhODYiLCJwIjoiaiJ9]

users table 에 맞는 엔티티 매핑