### PR TITLE
[FIX] User 알람 설정 컬럼 세분화 및 테스트/데이터 반영 (#44)

### DIFF
--- a/src/main/java/droni/backend/api/droniuser/entity/DroniUser.java
+++ b/src/main/java/droni/backend/api/droniuser/entity/DroniUser.java
@@ -40,8 +40,14 @@ public class DroniUser {
     private String addressDetail;
     @Column(unique = true)
     private String refreshToken;
-    private boolean notificationEnabled;
-    private boolean marketingEnabled;
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean appPushNotificationEnabled;
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean kakaoTalkNotificationEnabled;
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean chatNotificationEnabled;
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean estimateBidNotificationEnabled;
     @CreatedDate
     @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/droni/backend/oauth2/service/OAuth2UserPrincipal.java
+++ b/src/main/java/droni/backend/oauth2/service/OAuth2UserPrincipal.java
@@ -75,8 +75,10 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
                 .nickname(userInfo.getNickname())
                 .timeZone("Asia/Seoul")
                 .refreshToken(refreshToken)
-                .notificationEnabled(true)
-                .marketingEnabled(true)
+                .appPushNotificationEnabled(true)
+                .kakaoTalkNotificationEnabled(true)
+                .chatNotificationEnabled(true)
+                .estimateBidNotificationEnabled(true)
                 .build();
     }
 }

--- a/src/test/java/droni/backend/api/droniuser/repository/DroniUserRepositoryTest.java
+++ b/src/test/java/droni/backend/api/droniuser/repository/DroniUserRepositoryTest.java
@@ -69,6 +69,10 @@ class DroniUserRepositoryTest {
                         .phoneNumber("EMPTY_NUMBER")
                         .oauthId(NEW_USER_OAUTH_ID)
                         .refreshToken(NEW_USER_REFRESH_TOKEN)
+                        .appPushNotificationEnabled(true)
+                        .kakaoTalkNotificationEnabled(true)
+                        .chatNotificationEnabled(true)
+                        .estimateBidNotificationEnabled(true)
                         .build()
                 );
         Optional<DroniUser> droniUserByOauthId = userRepository.findByUserOauth2Id(NEW_USER_OAUTH_ID);

--- a/src/test/resources/testdata/test-expert.sql
+++ b/src/test/resources/testdata/test-expert.sql
@@ -1,18 +1,18 @@
 -- Create test users
 INSERT INTO users (phone_number, email, name, profile_image, nickname, zone_code, address, address_detail,
-                   refresh_token, notification_enabled, marketing_enabled, created_at, updated_at, deleted_at, provider,
+                   refresh_token, app_push_notification_enabled, kakao_talk_notification_enabled, chat_notification_enabled, estimate_bid_notification_enabled, created_at, updated_at, deleted_at, provider,
                    oauth_id)
 VALUES ('1234567890', 'test1@example.com', 'Test User1', 'http://example.com/profile1.jpg', 'Tester1', '10001',
-        '123 Test St', 'Apt 1', 'token1', true, false, '2023-01-01 12:00:00', '2023-01-01 12:00:00', NULL, 'GOOGLE',
+        '123 Test St', 'Apt 1', 'token1', true, true, true, true, '2023-01-01 12:00:00', '2023-01-01 12:00:00', NULL, 'GOOGLE',
         'oauth1'),
        ('1234567891', 'test2@example.com', 'Test User2', 'http://example.com/profile2.jpg', 'Tester2', '10002',
-        '456 Test St', 'Apt 2', 'token2', true, false, '2023-02-01 12:00:00', '2023-02-01 12:00:00', NULL, 'NAVER',
+        '456 Test St', 'Apt 2', 'token2', true, true, true, true, '2023-02-01 12:00:00', '2023-02-01 12:00:00', NULL, 'NAVER',
         'oauth2'),
        ('1234567892', 'test3@example.com', 'Test User3', 'http://example.com/profile3.jpg', 'Tester3', '10003',
-        '789 Test St', 'Apt 3', 'token3', true, false, '2023-03-01 12:00:00', '2023-03-01 12:00:00', NULL, 'KAKAO',
+        '789 Test St', 'Apt 3', 'token3', true, true, true, true, '2023-03-01 12:00:00', '2023-03-01 12:00:00', NULL, 'KAKAO',
         'oauth3'),
        ('1234567893', 'test4@example.com', 'Test User4', 'http://example.com/profile4.jpg', 'Tester4', '10004',
-        '789 Test St', 'Apt 3', 'token4', true, false, '2023-03-01 12:00:00', '2023-03-01 12:00:00', NULL, 'KAKAO',
+        '789 Test St', 'Apt 3', 'token4', true, true, true, true, '2023-03-01 12:00:00', '2023-03-01 12:00:00', NULL, 'KAKAO',
         'oauth4');
 
 INSERT INTO business_license (license_id, company_name, representative, company_address, company_address_detail)

--- a/src/test/resources/testdata/test-user-set.sql
+++ b/src/test/resources/testdata/test-user-set.sql
@@ -1,12 +1,12 @@
 INSERT INTO users (user_id, phone_number, email, name, profile_image, nickname, zone_code, address, address_detail,
-                   refresh_token, notification_enabled, marketing_enabled, created_at, updated_at, deleted_at, provider,
+                   refresh_token, app_push_notification_enabled, kakao_talk_notification_enabled, chat_notification_enabled, estimate_bid_notification_enabled, created_at, updated_at, deleted_at, provider,
                    oauth_id)
 VALUES (4, 'EMPTY_NUMBER', 'Taeyuntest@kakao.com', NULL,
         'http://k.kakaocdn.net/dn/oKUIq/btsGw7dsH0J/8u10RQbQHWk1mM46du7Cfk/test.jpg', 'Taeyun', 'Asia/Seoul',
         NULL, NULL,
         'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzYWRmYTdkNS02YWE0LTRkZjEtYTYwYi1iYTFmY2Y4OTE2NzkiLCJleHAiOjE3MTcyMjkyNzN9.rLdzDQujvVIudU7VbCdNCWUlkrUcaM8kpuiSRDqimfQ',
-        TRUE, TRUE, '2024-05-25 17:08:28.201082', '2024-05-25 17:08:28.201082', NULL, 'KAKAO', '3497839913'),
+        TRUE, TRUE, TRUE, TRUE, '2024-05-25 17:08:28.201082', '2024-05-25 17:08:28.201082', NULL, 'KAKAO', '3497839913'),
        (3, 'EMPTY_NUMBER', 'TaeyunTest@naver.com', '김태윤', NULL, NULL, 'Asia/Seoul', NULL, NULL,
         'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzNmQ5ZjU2Zi0wZjIyLTRiY2QtOWZmZS0zN2VhZTQyOWU4NmIiLCJleHAiOjE3MTg3MDk4Mzl9.GeTk0Dm1PicgHS5SXsGuGtnFOIOxMJGEZD5gTmBArqA',
-        TRUE, TRUE, '2024-05-11 19:07:16.276813', '2024-05-11 19:07:16.276813', NULL, 'NAVER',
+        TRUE, TRUE, TRUE, TRUE, '2024-05-11 19:07:16.276813', '2024-05-11 19:07:16.276813', NULL, 'NAVER',
         'Ai6kJjz8PehhWY3sVTYbIZomTTxkcghQSAtYThbfujY');


### PR DESCRIPTION
#### 변경 목적

- 기획에서 사용자의 "설정 > 알림 설정" 화면에 따라, 알림 설정을 세분화하였습니다.
    - **앱 푸시 알림**: 앱에 관련된 알림을 보내드려요
    - **카카오톡 알림**: 카카오톡으로 알림을 안내 해드려요
    - **채팅 알림**: 새로운 채팅이 오면 안내 해드려요
    - **견적 알림**: 새로운 견적이 입찰되면 안내 해드려요
- 기존 `notificationEnabled`, `marketingEnabled` 컬럼을 삭제하고, 위 4가지 알림 설정 컬럼으로 교체하였습니다.

---

#### 주요 변경사항

1. **Entity 변경**
    
    - `DroniUser`
        - 기존 알림/마케팅 설정 컬럼 제거
        - 아래 4개 필드 추가 및 기본값 false로 지정
            - `appPushNotificationEnabled`
            - `kakaoTalkNotificationEnabled`
            - `chatNotificationEnabled`
            - `estimateBidNotificationEnabled`
2. **OAuth2 신규 유저 생성 로직**
    
    - `OAuth2UserPrincipal`
        - 신규 유저 생성 시 위 4개 알림 필드를 모두 true로 설정
3. **테스트 코드 반영**
    
    - `DroniUserRepositoryTest`
        - 신규 유저 생성 및 mock 객체 생성 시 알림 필드 모두 true로 지정
4. **테스트 데이터 SQL 반영**
    
    - `test-expert.sql`
    - `test-user-set.sql`
        - users 테이블 컬럼 및 값 변경(알림 관련 컬럼 4개 추가, 기존 컬럼 제거)

---

#### 참고

- DB 마이그레이션 시 기존 users 테이블에 새로운 알림 컬럼 추가 필요
- 테스트 및 개발 환경에서 데이터 일관성 유지를 위해 SQL도 함께 수정됨

---

#### 관련 이슈

- #44

기획의 알림 설정 항목(앱 푸시, 카카오톡, 채팅, 견적 알림) 반영 완료하였습니다.  
리뷰 부탁드립니다.