### PR TITLE
[FEAT] 마이페이지 > 주소지 등록 기능 추가 (#45)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework:spring-webflux'
     testImplementation 'com.h2database:h2'
+    testImplementation 'org.springframework.security:spring-security-test'
 
 }
 test {

--- a/src/main/java/droni/backend/api/address/controller/AddressController.java
+++ b/src/main/java/droni/backend/api/address/controller/AddressController.java
@@ -6,6 +6,7 @@ import droni.backend.api.address.service.AddressService;
 import droni.backend.oauth2.service.OAuth2UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -32,7 +33,7 @@ public class AddressController {
     @ResponseStatus(HttpStatus.CREATED)
     public AddressResponse saveAddress(
             @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal,
-            @RequestBody AddressSaveRequest request
+            @Valid @RequestBody AddressSaveRequest request
     ) {
         return AddressResponse.from(addressService.saveAddress(userPrincipal, request));
     }

--- a/src/main/java/droni/backend/api/address/controller/AddressController.java
+++ b/src/main/java/droni/backend/api/address/controller/AddressController.java
@@ -7,7 +7,6 @@ import droni.backend.api.droniuser.entity.DroniUser;
 import droni.backend.api.droniuser.repository.DroniUserRepository;
 import droni.backend.oauth2.service.OAuth2UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +24,7 @@ public class AddressController {
     private final AddressService addressService;
     private final DroniUserRepository droniUserRepository;
 
-    @Operation(summary = "주소지 생성", security = @SecurityRequirement(name = "Authorization"))
+    @Operation(summary = "주소지 생성")
     @PostMapping
     public ResponseEntity<AddressResponse> saveAddress(
             @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal,
@@ -36,7 +35,7 @@ public class AddressController {
                 .ok(AddressResponse.from(addressService.saveAddress(user.getUserId(), request)));
     }
 
-    @Operation(summary = "주소지 목록 조회", security = @SecurityRequirement(name = "Authorization"))
+    @Operation(summary = "주소지 목록 조회")
     @GetMapping
     public ResponseEntity<List<AddressResponse>> getUserAddresses(
             @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal) {

--- a/src/main/java/droni/backend/api/address/controller/AddressController.java
+++ b/src/main/java/droni/backend/api/address/controller/AddressController.java
@@ -5,10 +5,12 @@ import droni.backend.api.address.dto.AddressSaveRequest;
 import droni.backend.api.address.service.AddressService;
 import droni.backend.api.droniuser.entity.DroniUser;
 import droni.backend.api.droniuser.repository.DroniUserRepository;
+import droni.backend.global.exception.DroniNotFoundException;
 import droni.backend.oauth2.service.OAuth2UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -30,7 +32,7 @@ public class AddressController {
             @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal,
             @RequestBody AddressSaveRequest request) {
         DroniUser user = droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
         return ResponseEntity
                 .ok(AddressResponse.from(addressService.saveAddress(user.getUserId(), request)));
     }
@@ -40,7 +42,7 @@ public class AddressController {
     public ResponseEntity<List<AddressResponse>> getUserAddresses(
             @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal) {
         DroniUser user = droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
         return ResponseEntity.ok(addressService.getUserAddresses(user.getUserId()).stream()
                 .map(AddressResponse::from).toList());
     }

--- a/src/main/java/droni/backend/api/address/controller/AddressController.java
+++ b/src/main/java/droni/backend/api/address/controller/AddressController.java
@@ -1,0 +1,48 @@
+package droni.backend.api.address.controller;
+
+import droni.backend.api.address.dto.AddressResponse;
+import droni.backend.api.address.dto.AddressSaveRequest;
+import droni.backend.api.address.service.AddressService;
+import droni.backend.api.droniuser.entity.DroniUser;
+import droni.backend.api.droniuser.repository.DroniUserRepository;
+import droni.backend.oauth2.service.OAuth2UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Address", description = "주소지 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/addresses")
+public class AddressController {
+
+    private final AddressService addressService;
+    private final DroniUserRepository droniUserRepository;
+
+    @Operation(summary = "주소지 생성", security = @SecurityRequirement(name = "Authorization"))
+    @PostMapping
+    public ResponseEntity<AddressResponse> saveAddress(
+            @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal,
+            @RequestBody AddressSaveRequest request) {
+        DroniUser user = droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return ResponseEntity
+                .ok(AddressResponse.from(addressService.saveAddress(user.getUserId(), request)));
+    }
+
+    @Operation(summary = "주소지 목록 조회", security = @SecurityRequirement(name = "Authorization"))
+    @GetMapping
+    public ResponseEntity<List<AddressResponse>> getUserAddresses(
+            @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal) {
+        DroniUser user = droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return ResponseEntity.ok(addressService.getUserAddresses(user.getUserId()).stream()
+                .map(AddressResponse::from).toList());
+    }
+}

--- a/src/main/java/droni/backend/api/address/controller/AddressController.java
+++ b/src/main/java/droni/backend/api/address/controller/AddressController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,22 +27,23 @@ public class AddressController {
 
     @Operation(summary = "주소지 생성")
     @PostMapping
-    public ResponseEntity<AddressResponse> saveAddress(
+    @ResponseStatus(HttpStatus.CREATED)
+    public AddressResponse saveAddress(
             @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal,
             @RequestBody AddressSaveRequest request) {
         DroniUser user = droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
                 .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
-        return ResponseEntity
-                .ok(AddressResponse.from(addressService.saveAddress(user.getUserId(), request)));
+        return AddressResponse.from(addressService.saveAddress(user.getUserId(), request));
     }
 
     @Operation(summary = "주소지 목록 조회")
     @GetMapping
-    public ResponseEntity<List<AddressResponse>> getUserAddresses(
+    public List<AddressResponse> getUserAddresses(
             @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal) {
         DroniUser user = droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
                 .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
-        return ResponseEntity.ok(addressService.getUserAddresses(user.getUserId()).stream()
-                .map(AddressResponse::from).toList());
+        return addressService.getUserAddresses(user.getUserId()).stream()
+                .map(AddressResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/droni/backend/api/address/controller/AddressController.java
+++ b/src/main/java/droni/backend/api/address/controller/AddressController.java
@@ -3,18 +3,21 @@ package droni.backend.api.address.controller;
 import droni.backend.api.address.dto.AddressResponse;
 import droni.backend.api.address.dto.AddressSaveRequest;
 import droni.backend.api.address.service.AddressService;
-import droni.backend.api.droniuser.entity.DroniUser;
-import droni.backend.api.droniuser.repository.DroniUserRepository;
-import droni.backend.global.exception.DroniNotFoundException;
 import droni.backend.oauth2.service.OAuth2UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Tag(name = "Address", description = "주소지 관련 API")
 @RestController
@@ -23,27 +26,24 @@ import java.util.List;
 public class AddressController {
 
     private final AddressService addressService;
-    private final DroniUserRepository droniUserRepository;
 
     @Operation(summary = "주소지 생성")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public AddressResponse saveAddress(
             @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal,
-            @RequestBody AddressSaveRequest request) {
-        DroniUser user = droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
-                .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
-        return AddressResponse.from(addressService.saveAddress(user.getUserId(), request));
+            @RequestBody AddressSaveRequest request
+    ) {
+        return AddressResponse.from(addressService.saveAddress(userPrincipal, request));
     }
 
     @Operation(summary = "주소지 목록 조회")
     @GetMapping
     public List<AddressResponse> getUserAddresses(
-            @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal) {
-        DroniUser user = droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
-                .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
-        return addressService.getUserAddresses(user.getUserId()).stream()
+            @AuthenticationPrincipal OAuth2UserPrincipal userPrincipal
+    ) {
+        return addressService.getUserAddresses(userPrincipal).stream()
                 .map(AddressResponse::from)
-                .toList();
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/droni/backend/api/address/dto/AddressResponse.java
+++ b/src/main/java/droni/backend/api/address/dto/AddressResponse.java
@@ -1,6 +1,7 @@
 package droni.backend.api.address.dto;
 
 import droni.backend.api.address.entity.UserAddress;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,7 +13,10 @@ public class AddressResponse {
 
     private final Long addressId;
     private final String addressName;
-    private final boolean isPrimary;
+
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+    private final Boolean isPrimary;
+
     private final String recipientName;
     private final String contactNumber;
     private final String address1;
@@ -20,7 +24,7 @@ public class AddressResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public AddressResponse(Long addressId, String addressName, boolean isPrimary,
+    public AddressResponse(Long addressId, String addressName, Boolean isPrimary,
             String recipientName, String contactNumber, String address1, String address2,
             LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.addressId = addressId;
@@ -35,10 +39,16 @@ public class AddressResponse {
     }
 
     public static AddressResponse from(UserAddress address) {
-        return AddressResponse.builder().addressId(address.getAddressId())
-                .addressName(address.getAddressName()).isPrimary(address.isPrimary())
-                .recipientName(address.getRecipientName()).contactNumber(address.getContactNumber())
-                .address1(address.getAddress1()).address2(address.getAddress2())
-                .createdAt(address.getCreatedAt()).updatedAt(address.getUpdatedAt()).build();
+        return AddressResponse.builder()
+                .addressId(address.getAddressId())
+                .addressName(address.getAddressName())
+                .isPrimary(address.isPrimary())
+                .recipientName(address.getRecipientName())
+                .contactNumber(address.getContactNumber())
+                .address1(address.getAddress1())
+                .address2(address.getAddress2())
+                .createdAt(address.getCreatedAt())
+                .updatedAt(address.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/droni/backend/api/address/dto/AddressResponse.java
+++ b/src/main/java/droni/backend/api/address/dto/AddressResponse.java
@@ -1,0 +1,44 @@
+package droni.backend.api.address.dto;
+
+import droni.backend.api.address.entity.UserAddress;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AddressResponse {
+
+    private final Long addressId;
+    private final String addressName;
+    private final boolean isPrimary;
+    private final String recipientName;
+    private final String contactNumber;
+    private final String address1;
+    private final String address2;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    @Builder
+    public AddressResponse(Long addressId, String addressName, boolean isPrimary,
+            String recipientName, String contactNumber, String address1, String address2,
+            LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.addressId = addressId;
+        this.addressName = addressName;
+        this.isPrimary = isPrimary;
+        this.recipientName = recipientName;
+        this.contactNumber = contactNumber;
+        this.address1 = address1;
+        this.address2 = address2;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static AddressResponse from(UserAddress address) {
+        return AddressResponse.builder().addressId(address.getAddressId())
+                .addressName(address.getAddressName()).isPrimary(address.isPrimary())
+                .recipientName(address.getRecipientName()).contactNumber(address.getContactNumber())
+                .address1(address.getAddress1()).address2(address.getAddress2())
+                .createdAt(address.getCreatedAt()).updatedAt(address.getUpdatedAt()).build();
+    }
+}

--- a/src/main/java/droni/backend/api/address/dto/AddressResponse.java
+++ b/src/main/java/droni/backend/api/address/dto/AddressResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 public class AddressResponse {
 
     private final Long addressId;
@@ -19,7 +20,6 @@ public class AddressResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    @Builder
     public AddressResponse(Long addressId, String addressName, boolean isPrimary,
             String recipientName, String contactNumber, String address1, String address2,
             LocalDateTime createdAt, LocalDateTime updatedAt) {

--- a/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
+++ b/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
@@ -33,8 +33,4 @@ public class AddressSaveRequest {
 
     @Size(max = 100, message = "상세주소는 100자 이하여야 합니다.")
     private String address2;
-
-    public void setPrimary(boolean primary) {
-        this.isPrimary = primary;
-    }
 }

--- a/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
+++ b/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
@@ -1,5 +1,8 @@
 package droni.backend.api.address.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,11 +11,27 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class AddressSaveRequest {
+
+    @NotBlank(message = "주소 이름은 필수입니다.")
+    @Size(max = 50, message = "주소 이름은 50자 이하여야 합니다.")
     private String addressName;
+
     private boolean isPrimary;
+
+    @NotBlank(message = "수령인 이름은 필수입니다.")
+    @Size(max = 20, message = "수령인 이름은 20자 이하여야 합니다.")
     private String recipientName;
+
+    @NotBlank(message = "연락처는 필수입니다.")
+    @Pattern(regexp = "^\\+?[1-9]\\d{1,14}$", message = "연락처는 숫자만 입력하세요. (국제번호는 +로 시작)")
+    @Size(min = 10, max = 15, message = "연락처는 10자 이상 15자 이하여야 합니다.")
     private String contactNumber;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    @Size(max = 100, message = "주소는 100자 이하여야 합니다.")
     private String address1;
+
+    @Size(max = 100, message = "상세주소는 100자 이하여야 합니다.")
     private String address2;
 
     public void setPrimary(boolean primary) {

--- a/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
+++ b/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
@@ -1,0 +1,19 @@
+package droni.backend.api.address.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AddressSaveRequest {
+    private String addressName;
+    private boolean isPrimary;
+    private String recipientName;
+    private String contactNumber;
+    private String address1;
+    private String address2;
+
+    public void setPrimary(boolean primary) {
+        this.isPrimary = primary;
+    }
+}

--- a/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
+++ b/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
@@ -1,6 +1,7 @@
 package droni.backend.api.address.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -16,7 +17,8 @@ public class AddressSaveRequest {
     @Size(max = 50, message = "주소 이름은 50자 이하여야 합니다.")
     private String addressName;
 
-    private boolean isPrimary;
+    @NotNull(message = "기본 주소 여부는 필수입니다.")
+    private Boolean isPrimary;
 
     @NotBlank(message = "수령인 이름은 필수입니다.")
     @Size(max = 20, message = "수령인 이름은 20자 이하여야 합니다.")

--- a/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
+++ b/src/main/java/droni/backend/api/address/dto/AddressSaveRequest.java
@@ -2,8 +2,10 @@ package droni.backend.api.address.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class AddressSaveRequest {
     private String addressName;

--- a/src/main/java/droni/backend/api/address/entity/UserAddress.java
+++ b/src/main/java/droni/backend/api/address/entity/UserAddress.java
@@ -1,0 +1,71 @@
+package droni.backend.api.address.entity;
+
+import droni.backend.api.droniuser.entity.DroniUser;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserAddress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "address_id")
+    private Long addressId;
+
+    private String addressName;
+    private boolean isPrimary;
+    private String recipientName;
+    private String contactNumber;
+    private String address1;
+    private String address2;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private DroniUser user;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public UserAddress(Long addressId, String addressName, boolean isPrimary, String recipientName,
+            String contactNumber, String address1, String address2, DroniUser user) {
+        this.addressId = addressId;
+        this.addressName = addressName;
+        this.isPrimary = isPrimary;
+        this.recipientName = recipientName;
+        this.contactNumber = contactNumber;
+        this.address1 = address1;
+        this.address2 = address2;
+        this.user = user;
+    }
+
+    @Builder
+    public UserAddress(String addressName, boolean isPrimary, String recipientName,
+            String contactNumber, String address1, String address2, DroniUser user) {
+        this.addressName = addressName;
+        this.isPrimary = isPrimary;
+        this.recipientName = recipientName;
+        this.contactNumber = contactNumber;
+        this.address1 = address1;
+        this.address2 = address2;
+        this.user = user;
+    }
+
+    public void setPrimary(boolean isPrimary) {
+        this.isPrimary = isPrimary;
+    }
+}

--- a/src/main/java/droni/backend/api/address/entity/UserAddress.java
+++ b/src/main/java/droni/backend/api/address/entity/UserAddress.java
@@ -13,6 +13,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "user_address", indexes = @Index(name = "idx_user_id", columnList = "user_id"))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/droni/backend/api/address/entity/UserAddress.java
+++ b/src/main/java/droni/backend/api/address/entity/UserAddress.java
@@ -45,26 +45,6 @@ public class UserAddress {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public UserAddress(
-        Long addressId,
-        String addressName,
-        boolean isPrimary,
-        String recipientName,
-        String contactNumber,
-        String address1,
-        String address2,
-        DroniUser user
-    ) {
-        this.addressId = addressId;
-        this.addressName = addressName;
-        this.isPrimary = isPrimary;
-        this.recipientName = recipientName;
-        this.contactNumber = contactNumber;
-        this.address1 = address1;
-        this.address2 = address2;
-        this.user = user;
-    }
-
     @Builder(access = AccessLevel.PRIVATE)
     public UserAddress(
         String addressName,

--- a/src/main/java/droni/backend/api/address/entity/UserAddress.java
+++ b/src/main/java/droni/backend/api/address/entity/UserAddress.java
@@ -104,6 +104,20 @@ public class UserAddress {
             .build();
     }
 
+    public void updateAddress(
+        String addressName,
+        String recipientName,
+        String contactNumber,
+        String address1,
+        String address2
+    ) {
+        this.addressName = addressName;
+        this.recipientName = recipientName;
+        this.contactNumber = contactNumber;
+        this.address1 = address1;
+        this.address2 = address2;
+    }
+
     public void setPrimary(boolean isPrimary) {
         this.isPrimary = isPrimary;
     }

--- a/src/main/java/droni/backend/api/address/entity/UserAddress.java
+++ b/src/main/java/droni/backend/api/address/entity/UserAddress.java
@@ -28,7 +28,10 @@ public class UserAddress {
     private Long addressId;
 
     private String addressName;
-    private boolean isPrimary;
+
+    @Column(name = "is_primary", nullable = false)
+    private boolean primary;
+
     private String recipientName;
     private String contactNumber;
     private String address1;
@@ -48,7 +51,7 @@ public class UserAddress {
     @Builder(access = AccessLevel.PRIVATE)
     public UserAddress(
         String addressName,
-        boolean isPrimary,
+        boolean primary,
         String recipientName,
         String contactNumber,
         String address1,
@@ -56,7 +59,7 @@ public class UserAddress {
         DroniUser user
     ) {
         this.addressName = addressName;
-        this.isPrimary = isPrimary;
+        this.primary = primary;
         this.recipientName = recipientName;
         this.contactNumber = contactNumber;
         this.address1 = address1;
@@ -66,7 +69,7 @@ public class UserAddress {
 
     public static UserAddress create(
         String addressName,
-        boolean isPrimary,
+        boolean primary,
         String recipientName,
         String contactNumber,
         String address1,
@@ -75,7 +78,7 @@ public class UserAddress {
     ) {
         return UserAddress.builder()
             .addressName(addressName)
-            .isPrimary(isPrimary)
+            .primary(primary)
             .recipientName(recipientName)
             .contactNumber(contactNumber)
             .address1(address1)
@@ -98,7 +101,7 @@ public class UserAddress {
         this.address2 = address2;
     }
 
-    public void setPrimary(boolean isPrimary) {
-        this.isPrimary = isPrimary;
+    public void updatePrimary(boolean primary) {
+        this.primary = primary;
     }
 }

--- a/src/main/java/droni/backend/api/address/entity/UserAddress.java
+++ b/src/main/java/droni/backend/api/address/entity/UserAddress.java
@@ -13,7 +13,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user_address", indexes = @Index(name = "idx_user_id", columnList = "user_id"))
+@Table(
+    name = "user_address",
+    indexes = @Index(name = "idx_user_id", columnList = "user_id")
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
@@ -42,8 +45,16 @@ public class UserAddress {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public UserAddress(Long addressId, String addressName, boolean isPrimary, String recipientName,
-            String contactNumber, String address1, String address2, DroniUser user) {
+    public UserAddress(
+        Long addressId,
+        String addressName,
+        boolean isPrimary,
+        String recipientName,
+        String contactNumber,
+        String address1,
+        String address2,
+        DroniUser user
+    ) {
         this.addressId = addressId;
         this.addressName = addressName;
         this.isPrimary = isPrimary;
@@ -54,9 +65,16 @@ public class UserAddress {
         this.user = user;
     }
 
-    @Builder
-    public UserAddress(String addressName, boolean isPrimary, String recipientName,
-            String contactNumber, String address1, String address2, DroniUser user) {
+    @Builder(access = AccessLevel.PRIVATE)
+    public UserAddress(
+        String addressName,
+        boolean isPrimary,
+        String recipientName,
+        String contactNumber,
+        String address1,
+        String address2,
+        DroniUser user
+    ) {
         this.addressName = addressName;
         this.isPrimary = isPrimary;
         this.recipientName = recipientName;
@@ -64,6 +82,26 @@ public class UserAddress {
         this.address1 = address1;
         this.address2 = address2;
         this.user = user;
+    }
+
+    public static UserAddress create(
+        String addressName,
+        boolean isPrimary,
+        String recipientName,
+        String contactNumber,
+        String address1,
+        String address2,
+        DroniUser user
+    ) {
+        return UserAddress.builder()
+            .addressName(addressName)
+            .isPrimary(isPrimary)
+            .recipientName(recipientName)
+            .contactNumber(contactNumber)
+            .address1(address1)
+            .address2(address2)
+            .user(user)
+            .build();
     }
 
     public void setPrimary(boolean isPrimary) {

--- a/src/main/java/droni/backend/api/address/repository/UserAddressRepository.java
+++ b/src/main/java/droni/backend/api/address/repository/UserAddressRepository.java
@@ -1,0 +1,11 @@
+package droni.backend.api.address.repository;
+
+import droni.backend.api.address.entity.UserAddress;
+import droni.backend.api.droniuser.entity.DroniUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserAddressRepository extends JpaRepository<UserAddress, Long> {
+    List<UserAddress> findByUser(DroniUser user);
+}

--- a/src/main/java/droni/backend/api/address/repository/UserAddressRepository.java
+++ b/src/main/java/droni/backend/api/address/repository/UserAddressRepository.java
@@ -5,7 +5,14 @@ import droni.backend.api.droniuser.entity.DroniUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserAddressRepository extends JpaRepository<UserAddress, Long> {
     List<UserAddress> findByUser(DroniUser user);
+
+    // 유저의 기본 주소를 단건 조회
+    Optional<UserAddress> findByUserAndPrimaryTrue(DroniUser user);
+
+    // 유저가 주소를 하나라도 갖고 있는지 여부
+    boolean existsByUser(DroniUser user);
 }

--- a/src/main/java/droni/backend/api/address/service/AddressService.java
+++ b/src/main/java/droni/backend/api/address/service/AddressService.java
@@ -23,7 +23,7 @@ public class AddressService {
 
     public UserAddress saveAddress(Long userId, AddressSaveRequest request) {
         DroniUser user = droniUserRepository.findById(userId)
-                .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+            .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
 
         List<UserAddress> existingAddresses = userAddressRepository.findByUser(user);
 
@@ -35,22 +35,28 @@ public class AddressService {
         } else {
             if (isNewAddressPrimary) {
                 // 새 주소가 기본 주소로 지정되면 기존 기본 주소를 모두 false로 변경
-                existingAddresses.stream().filter(UserAddress::isPrimary)
-                        .forEach(address -> address.setPrimary(false));
+                existingAddresses.stream()
+                    .filter(UserAddress::isPrimary)
+                    .forEach(address -> address.setPrimary(false));
             } else {
                 // 새 주소가 기본이 아니지만 기존에 기본 주소가 없다면 새 주소를 기본으로 지정
-                boolean hasExistingPrimary =
-                        existingAddresses.stream().anyMatch(UserAddress::isPrimary);
+                boolean hasExistingPrimary = existingAddresses.stream()
+                    .anyMatch(UserAddress::isPrimary);
                 if (!hasExistingPrimary) {
                     isNewAddressPrimary = true;
                 }
             }
         }
 
-        UserAddress newAddress = UserAddress.builder().user(user)
-                .addressName(request.getAddressName()).isPrimary(isNewAddressPrimary)
-                .recipientName(request.getRecipientName()).contactNumber(request.getContactNumber())
-                .address1(request.getAddress1()).address2(request.getAddress2()).build();
+        UserAddress newAddress = UserAddress.create(
+            request.getAddressName(),
+            isNewAddressPrimary,
+            request.getRecipientName(),
+            request.getContactNumber(),
+            request.getAddress1(),
+            request.getAddress2(),
+            user
+        );
 
         return userAddressRepository.save(newAddress);
     }
@@ -58,7 +64,7 @@ public class AddressService {
     @Transactional(readOnly = true)
     public List<UserAddress> getUserAddresses(Long userId) {
         DroniUser user = droniUserRepository.findById(userId)
-                .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+            .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
         return userAddressRepository.findByUser(user);
     }
 }

--- a/src/main/java/droni/backend/api/address/service/AddressService.java
+++ b/src/main/java/droni/backend/api/address/service/AddressService.java
@@ -26,26 +26,17 @@ public class AddressService {
             .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
 
         List<UserAddress> existingAddresses = userAddressRepository.findByUser(user);
-
         boolean isNewAddressPrimary = request.isPrimary();
 
         if (existingAddresses.isEmpty()) {
-            // 첫 번째 주소는 반드시 기본 주소여야 함
             isNewAddressPrimary = true;
-        } else {
-            if (isNewAddressPrimary) {
-                // 새 주소가 기본 주소로 지정되면 기존 기본 주소를 모두 false로 변경
-                existingAddresses.stream()
-                    .filter(UserAddress::isPrimary)
-                    .forEach(address -> address.setPrimary(false));
-            } else {
-                // 새 주소가 기본이 아니지만 기존에 기본 주소가 없다면 새 주소를 기본으로 지정
-                boolean hasExistingPrimary = existingAddresses.stream()
-                    .anyMatch(UserAddress::isPrimary);
-                if (!hasExistingPrimary) {
-                    isNewAddressPrimary = true;
-                }
-            }
+        }
+        else if (isNewAddressPrimary) {
+            existingAddresses.stream().filter(UserAddress::isPrimary).findFirst()
+                    .ifPresent(addr -> addr.setPrimary(false));
+        }
+        else if (existingAddresses.stream().noneMatch(UserAddress::isPrimary)) {
+            isNewAddressPrimary = true;
         }
 
         UserAddress newAddress = UserAddress.create(

--- a/src/main/java/droni/backend/api/address/service/AddressService.java
+++ b/src/main/java/droni/backend/api/address/service/AddressService.java
@@ -5,7 +5,9 @@ import droni.backend.api.address.entity.UserAddress;
 import droni.backend.api.address.repository.UserAddressRepository;
 import droni.backend.api.droniuser.entity.DroniUser;
 import droni.backend.api.droniuser.repository.DroniUserRepository;
+import droni.backend.global.exception.DroniNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +23,7 @@ public class AddressService {
 
     public UserAddress saveAddress(Long userId, AddressSaveRequest request) {
         DroniUser user = droniUserRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
 
         List<UserAddress> existingAddresses = userAddressRepository.findByUser(user);
 
@@ -56,7 +58,7 @@ public class AddressService {
     @Transactional(readOnly = true)
     public List<UserAddress> getUserAddresses(Long userId) {
         DroniUser user = droniUserRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
         return userAddressRepository.findByUser(user);
     }
 }

--- a/src/main/java/droni/backend/api/address/service/AddressService.java
+++ b/src/main/java/droni/backend/api/address/service/AddressService.java
@@ -21,6 +21,10 @@ public class AddressService {
     private final UserAddressRepository userAddressRepository;
     private final DroniUserRepository droniUserRepository;
 
+    /**
+     * 사용자의 주소를 저장합니다. 첫 주소 또는 기존 주소가 모두 비활성화된 경우 기본 주소로 설정합니다.
+     * 기본 주소로 저장 시 기존 기본 주소는 비활성화됩니다.
+     */
     public UserAddress saveAddress(Long userId, AddressSaveRequest request) {
         DroniUser user = droniUserRepository.findById(userId)
             .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
@@ -30,12 +34,12 @@ public class AddressService {
 
         if (existingAddresses.isEmpty()) {
             isNewAddressPrimary = true;
-        }
-        else if (isNewAddressPrimary) {
-            existingAddresses.stream().filter(UserAddress::isPrimary).findFirst()
-                    .ifPresent(addr -> addr.setPrimary(false));
-        }
-        else if (existingAddresses.stream().noneMatch(UserAddress::isPrimary)) {
+        } else if (isNewAddressPrimary) {
+            existingAddresses.stream()
+                .filter(UserAddress::isPrimary)
+                .findFirst()
+                .ifPresent(addr -> addr.setPrimary(false));
+        } else if (existingAddresses.stream().noneMatch(UserAddress::isPrimary)) {
             isNewAddressPrimary = true;
         }
 
@@ -52,6 +56,9 @@ public class AddressService {
         return userAddressRepository.save(newAddress);
     }
 
+    /**
+     * 사용자의 모든 주소 목록을 조회합니다.
+     */
     @Transactional(readOnly = true)
     public List<UserAddress> getUserAddresses(Long userId) {
         DroniUser user = droniUserRepository.findById(userId)

--- a/src/main/java/droni/backend/api/address/service/AddressService.java
+++ b/src/main/java/droni/backend/api/address/service/AddressService.java
@@ -28,24 +28,19 @@ public class AddressService {
      */
     public UserAddress saveAddress(OAuth2UserPrincipal userPrincipal, AddressSaveRequest request) {
         DroniUser user = findUserByPrincipal(userPrincipal);
-
         List<UserAddress> existingAddresses = userAddressRepository.findByUser(user);
-        boolean isNewAddressPrimary = request.getIsPrimary();
 
-        if (existingAddresses.isEmpty()) {
-            isNewAddressPrimary = true;
-        } else if (isNewAddressPrimary) {
+        boolean shouldBePrimary = resolvePrimaryFlag(request.getIsPrimary(), existingAddresses);
+        if (shouldBePrimary) {
             existingAddresses.stream()
                 .filter(UserAddress::isPrimary)
                 .findFirst()
                 .ifPresent(addr -> addr.updatePrimary(false));
-        } else if (existingAddresses.stream().noneMatch(UserAddress::isPrimary)) {
-            isNewAddressPrimary = true;
         }
 
         UserAddress newAddress = UserAddress.create(
             request.getAddressName(),
-            isNewAddressPrimary,
+            shouldBePrimary,
             request.getRecipientName(),
             request.getContactNumber(),
             request.getAddress1(),
@@ -68,5 +63,18 @@ public class AddressService {
     private DroniUser findUserByPrincipal(OAuth2UserPrincipal userPrincipal) {
         return droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
             .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+    }
+
+    private boolean resolvePrimaryFlag(boolean requestedPrimary, List<UserAddress> existingAddresses) {
+        if (existingAddresses.isEmpty()) {
+            return true;
+        }
+
+        boolean hasPrimary = existingAddresses.stream().anyMatch(UserAddress::isPrimary);
+        if (!hasPrimary) {
+            return true;
+        }
+
+        return requestedPrimary;
     }
 }

--- a/src/main/java/droni/backend/api/address/service/AddressService.java
+++ b/src/main/java/droni/backend/api/address/service/AddressService.java
@@ -28,13 +28,21 @@ public class AddressService {
      */
     public UserAddress saveAddress(OAuth2UserPrincipal userPrincipal, AddressSaveRequest request) {
         DroniUser user = findUserByPrincipal(userPrincipal);
-        List<UserAddress> existingAddresses = userAddressRepository.findByUser(user);
 
-        boolean shouldBePrimary = resolvePrimaryFlag(request.getIsPrimary(), existingAddresses);
+        boolean userHasAnyAddress = userAddressRepository.existsByUser(user);
+        boolean hasPrimary = userAddressRepository.findByUserAndPrimaryTrue(user).isPresent();
+
+        boolean shouldBePrimary;
+        if (!userHasAnyAddress) {
+            shouldBePrimary = true;
+        } else if (!hasPrimary) {
+            shouldBePrimary = true;
+        } else {
+            shouldBePrimary = Boolean.TRUE.equals(request.getIsPrimary());
+        }
+
         if (shouldBePrimary) {
-            existingAddresses.stream()
-                .filter(UserAddress::isPrimary)
-                .findFirst()
+            userAddressRepository.findByUserAndPrimaryTrue(user)
                 .ifPresent(addr -> addr.updatePrimary(false));
         }
 
@@ -63,18 +71,5 @@ public class AddressService {
     private DroniUser findUserByPrincipal(OAuth2UserPrincipal userPrincipal) {
         return droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
             .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
-    }
-
-    private boolean resolvePrimaryFlag(boolean requestedPrimary, List<UserAddress> existingAddresses) {
-        if (existingAddresses.isEmpty()) {
-            return true;
-        }
-
-        boolean hasPrimary = existingAddresses.stream().anyMatch(UserAddress::isPrimary);
-        if (!hasPrimary) {
-            return true;
-        }
-
-        return requestedPrimary;
     }
 }

--- a/src/main/java/droni/backend/api/address/service/AddressService.java
+++ b/src/main/java/droni/backend/api/address/service/AddressService.java
@@ -1,0 +1,62 @@
+package droni.backend.api.address.service;
+
+import droni.backend.api.address.dto.AddressSaveRequest;
+import droni.backend.api.address.entity.UserAddress;
+import droni.backend.api.address.repository.UserAddressRepository;
+import droni.backend.api.droniuser.entity.DroniUser;
+import droni.backend.api.droniuser.repository.DroniUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AddressService {
+
+    private final UserAddressRepository userAddressRepository;
+    private final DroniUserRepository droniUserRepository;
+
+    public UserAddress saveAddress(Long userId, AddressSaveRequest request) {
+        DroniUser user = droniUserRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        List<UserAddress> existingAddresses = userAddressRepository.findByUser(user);
+
+        boolean isNewAddressPrimary = request.isPrimary();
+
+        if (existingAddresses.isEmpty()) {
+            // 첫 번째 주소는 반드시 기본 주소여야 함
+            isNewAddressPrimary = true;
+        } else {
+            if (isNewAddressPrimary) {
+                // 새 주소가 기본 주소로 지정되면 기존 기본 주소를 모두 false로 변경
+                existingAddresses.stream().filter(UserAddress::isPrimary)
+                        .forEach(address -> address.setPrimary(false));
+            } else {
+                // 새 주소가 기본이 아니지만 기존에 기본 주소가 없다면 새 주소를 기본으로 지정
+                boolean hasExistingPrimary =
+                        existingAddresses.stream().anyMatch(UserAddress::isPrimary);
+                if (!hasExistingPrimary) {
+                    isNewAddressPrimary = true;
+                }
+            }
+        }
+
+        UserAddress newAddress = UserAddress.builder().user(user)
+                .addressName(request.getAddressName()).isPrimary(isNewAddressPrimary)
+                .recipientName(request.getRecipientName()).contactNumber(request.getContactNumber())
+                .address1(request.getAddress1()).address2(request.getAddress2()).build();
+
+        return userAddressRepository.save(newAddress);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserAddress> getUserAddresses(Long userId) {
+        DroniUser user = droniUserRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return userAddressRepository.findByUser(user);
+    }
+}

--- a/src/main/java/droni/backend/api/address/service/AddressService.java
+++ b/src/main/java/droni/backend/api/address/service/AddressService.java
@@ -30,7 +30,7 @@ public class AddressService {
         DroniUser user = findUserByPrincipal(userPrincipal);
 
         List<UserAddress> existingAddresses = userAddressRepository.findByUser(user);
-        boolean isNewAddressPrimary = request.isPrimary();
+        boolean isNewAddressPrimary = request.getIsPrimary();
 
         if (existingAddresses.isEmpty()) {
             isNewAddressPrimary = true;
@@ -38,7 +38,7 @@ public class AddressService {
             existingAddresses.stream()
                 .filter(UserAddress::isPrimary)
                 .findFirst()
-                .ifPresent(addr -> addr.setPrimary(false));
+                .ifPresent(addr -> addr.updatePrimary(false));
         } else if (existingAddresses.stream().noneMatch(UserAddress::isPrimary)) {
             isNewAddressPrimary = true;
         }

--- a/src/main/java/droni/backend/api/address/service/AddressService.java
+++ b/src/main/java/droni/backend/api/address/service/AddressService.java
@@ -6,6 +6,7 @@ import droni.backend.api.address.repository.UserAddressRepository;
 import droni.backend.api.droniuser.entity.DroniUser;
 import droni.backend.api.droniuser.repository.DroniUserRepository;
 import droni.backend.global.exception.DroniNotFoundException;
+import droni.backend.oauth2.service.OAuth2UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -25,9 +26,8 @@ public class AddressService {
      * 사용자의 주소를 저장합니다. 첫 주소 또는 기존 주소가 모두 비활성화된 경우 기본 주소로 설정합니다.
      * 기본 주소로 저장 시 기존 기본 주소는 비활성화됩니다.
      */
-    public UserAddress saveAddress(Long userId, AddressSaveRequest request) {
-        DroniUser user = droniUserRepository.findById(userId)
-            .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+    public UserAddress saveAddress(OAuth2UserPrincipal userPrincipal, AddressSaveRequest request) {
+        DroniUser user = findUserByPrincipal(userPrincipal);
 
         List<UserAddress> existingAddresses = userAddressRepository.findByUser(user);
         boolean isNewAddressPrimary = request.isPrimary();
@@ -60,9 +60,13 @@ public class AddressService {
      * 사용자의 모든 주소 목록을 조회합니다.
      */
     @Transactional(readOnly = true)
-    public List<UserAddress> getUserAddresses(Long userId) {
-        DroniUser user = droniUserRepository.findById(userId)
-            .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+    public List<UserAddress> getUserAddresses(OAuth2UserPrincipal userPrincipal) {
+        DroniUser user = findUserByPrincipal(userPrincipal);
         return userAddressRepository.findByUser(user);
+    }
+
+    private DroniUser findUserByPrincipal(OAuth2UserPrincipal userPrincipal) {
+        return droniUserRepository.findByOauthId(userPrincipal.getOAuth2Id())
+            .orElseThrow(() -> new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/droni/backend/api/droniuser/repository/DroniUserQuerydslRepository.java
+++ b/src/main/java/droni/backend/api/droniuser/repository/DroniUserQuerydslRepository.java
@@ -6,6 +6,7 @@ import droni.backend.oauth2.service.OAuth2UserPrincipal;
 import java.util.Optional;
 
 public interface DroniUserQuerydslRepository {
+
     Optional<DroniUser> findByUserOauth2Id(String oauth2Id);
 
     DroniUser findUserFromContextHolder();
@@ -13,4 +14,6 @@ public interface DroniUserQuerydslRepository {
     Optional<DroniUser> findReissueUser(String oauth2Id, String refreshToken);
 
     DroniUser updateWithPrincipal(String newRefreshToken, OAuth2UserPrincipal userPrincipal);
+
+    Optional<DroniUser> findByOauthId(String oauthId);
 }

--- a/src/main/java/droni/backend/api/droniuser/repository/DroniUserQuerydslRepositoryImpl.java
+++ b/src/main/java/droni/backend/api/droniuser/repository/DroniUserQuerydslRepositoryImpl.java
@@ -22,55 +22,59 @@ import java.util.Optional;
 @Repository
 @Slf4j
 @RequiredArgsConstructor
-public class DroniUserQuerydslRepositoryImpl implements DroniUserQuerydslRepository{
+public class DroniUserQuerydslRepositoryImpl implements DroniUserQuerydslRepository {
+
     private final JPAQueryFactory jpaQueryFactory;
     private final EntityManager em;
-
-
     private final QDroniUser droniUser = QDroniUser.droniUser;
 
     @Override
     public Optional<DroniUser> findByUserOauth2Id(String oauth2Id) {
-        return Optional.ofNullable(jpaQueryFactory.selectFrom(droniUser).where(oauth2IdEq(oauth2Id)).fetchFirst());
+        return Optional.ofNullable(
+                jpaQueryFactory.selectFrom(droniUser).where(oauth2IdEq(oauth2Id)).fetchFirst());
     }
 
     @Override
     public DroniUser findUserFromContextHolder() {
-
         SecurityContext context = SecurityContextHolder.getContext();
         Authentication authentication = context.getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || Objects.isNull(authentication.getPrincipal())) {
-            throw new DroniUserException(HttpStatus.UNAUTHORIZED, "Authentication required or token for testing given");
+
+        if (authentication == null || !authentication.isAuthenticated()
+                || Objects.isNull(authentication.getPrincipal())) {
+            throw new DroniUserException(HttpStatus.UNAUTHORIZED,
+                    "Authentication required or token for testing given");
         }
+
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        Optional<DroniUser> findDroniUser = Optional.ofNullable(jpaQueryFactory.selectFrom(droniUser).where(oauth2IdEq(userDetails.getUsername())).fetchFirst());
-        return findDroniUser.orElseThrow(() -> new DroniUserException(HttpStatus.BAD_REQUEST, "Login user not found"));
+        Optional<DroniUser> findDroniUser = Optional.ofNullable(jpaQueryFactory
+                .selectFrom(droniUser).where(oauth2IdEq(userDetails.getUsername())).fetchFirst());
+
+        return findDroniUser.orElseThrow(
+                () -> new DroniUserException(HttpStatus.BAD_REQUEST, "Login user not found"));
     }
 
     @Override
     public Optional<DroniUser> findReissueUser(String oauth2Id, String refreshToken) {
-        return  Optional.ofNullable(jpaQueryFactory.selectFrom(droniUser)
-                .where(oauth2IdEq(oauth2Id), refreshTokenEq(refreshToken))
-                .fetchFirst());
+        return Optional.ofNullable(jpaQueryFactory.selectFrom(droniUser)
+                .where(oauth2IdEq(oauth2Id), refreshTokenEq(refreshToken)).fetchFirst());
     }
 
     private BooleanExpression refreshTokenEq(String refreshToken) {
         return droniUser.refreshToken.eq(refreshToken);
     }
 
-    private BooleanExpression oauth2IdEq(String expiredAccessToken) {
-        return droniUser.oauthId.eq(expiredAccessToken);
+    private BooleanExpression oauth2IdEq(String oauth2Id) {
+        return droniUser.oauthId.eq(oauth2Id);
     }
 
     @Override
-    public DroniUser updateWithPrincipal(String newRefreshToken, OAuth2UserPrincipal userPrincipal) {
+    public DroniUser updateWithPrincipal(String newRefreshToken,
+            OAuth2UserPrincipal userPrincipal) {
+        Optional<DroniUser> optionalUser = Optional.ofNullable(jpaQueryFactory.selectFrom(droniUser)
+                .where(oauth2IdEq(userPrincipal.getOAuth2Id())).fetchFirst());
 
-        Optional<DroniUser> optinalUser = Optional.ofNullable(jpaQueryFactory.selectFrom(droniUser)
-                .where(oauth2IdEq(userPrincipal.getOAuth2Id()))
-                .fetchFirst()
-        );
-        if (optinalUser.isPresent()) {
-            DroniUser existUser = optinalUser.get();
+        if (optionalUser.isPresent()) {
+            DroniUser existUser = optionalUser.get();
             existUser.updateRefreshToken(newRefreshToken);
             return existUser;
         } else {
@@ -78,6 +82,11 @@ public class DroniUserQuerydslRepositoryImpl implements DroniUserQuerydslReposit
             em.persist(newUser);
             return newUser;
         }
+    }
 
+    @Override
+    public Optional<DroniUser> findByOauthId(String oauthId) {
+        return Optional.ofNullable(
+                jpaQueryFactory.selectFrom(droniUser).where(oauth2IdEq(oauthId)).fetchFirst());
     }
 }

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -149,4 +149,37 @@ class AddressControllerTest {
         verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
         verify(addressService).saveAddress(eq(testUser.getUserId()), any(AddressSaveRequest.class));
     }
+
+    @Test
+    @DisplayName("POST /api/v1/addresses - 인증 정보에 해당하는 사용자를 찾을 수 없을 때 404 반환")
+    void saveAddress_userNotFound_shouldReturn404() throws Exception {
+        // Given
+        AddressSaveRequest request = new AddressSaveRequest();
+        request.setAddressName("테스트 주소");
+        request.setRecipientName("홍길동");
+        request.setContactNumber("010-1234-5678");
+        request.setAddress1("서울시 강남구");
+        request.setAddress2("101호");
+        request.setPrimary(true);
+
+        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
+                .thenReturn(Optional.empty());
+
+        TestingAuthenticationToken authentication =
+                new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/addresses").principal(authentication)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(authentication(authentication)).with(csrf())).andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("유저를 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.exception").value("DroniNotFoundException"))
+                .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.path").value("/api/v1/addresses"))
+                .andExpect(jsonPath("$.timestamp").isNotEmpty());
+
+        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
+        // AddressService.saveAddress는 호출되지 않아야 함
+    }
 }

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -24,13 +24,11 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -113,9 +111,6 @@ class AddressControllerTest {
             request.getAddressName(), request.getIsPrimary(), request.getRecipientName(),
             request.getContactNumber(), request.getAddress1(), request.getAddress2(), testUser
         );
-        LocalDateTime now = LocalDateTime.now();
-        doReturn(now).when(savedAddress).getCreatedAt();
-        doReturn(now).when(savedAddress).getUpdatedAt();
 
         when(addressService.saveAddress(any(OAuth2UserPrincipal.class), any(AddressSaveRequest.class)))
             .thenReturn(savedAddress);
@@ -162,13 +157,8 @@ class AddressControllerTest {
     @DisplayName("GET /api/v1/addresses - 주소지 목록 조회 성공")
     void getUserAddresses_success() throws Exception {
         // Given
-        LocalDateTime now = LocalDateTime.now();
         UserAddress address1 = UserAddress.create("집", true, "홍길동", "010-1111-2222", "서울시 강남구", "101호", testUser);
         UserAddress address2 = UserAddress.create("회사", false, "홍길동", "010-3333-4444", "서울시 서초구", "202호", testUser);
-        doReturn(now).when(address1).getCreatedAt();
-        doReturn(now).when(address1).getUpdatedAt();
-        doReturn(now).when(address2).getCreatedAt();
-        doReturn(now).when(address2).getUpdatedAt();
 
         when(addressService.getUserAddresses(any(OAuth2UserPrincipal.class)))
             .thenReturn(List.of(address1, address2));

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -1,89 +1,152 @@
 package droni.backend.api.address.controller;
 
-import droni.backend.api.address.dto.AddressResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import droni.backend.api.address.dto.AddressSaveRequest;
 import droni.backend.api.address.entity.UserAddress;
 import droni.backend.api.address.service.AddressService;
 import droni.backend.api.droniuser.entity.DroniUser;
 import droni.backend.api.droniuser.repository.DroniUserRepository;
+import droni.backend.oauth2.jwt.TokenAuthenticationFilter;
 import droni.backend.oauth2.service.OAuth2UserPrincipal;
 import droni.backend.oauth2.user.impl.NaverOAuth2UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 
-@ExtendWith(MockitoExtension.class)
+@WebMvcTest(
+    controllers = AddressController.class,
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = TokenAuthenticationFilter.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = org.springframework.data.jpa.mapping.JpaMetamodelMappingContext.class)
+    }
+)
 class AddressControllerTest {
 
-    @Mock
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
     private AddressService addressService;
 
-    @Mock
+    @MockBean
     private DroniUserRepository droniUserRepository;
 
-    @InjectMocks
-    private AddressController addressController;
+    @MockBean
+    private org.springframework.data.jpa.mapping.JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
-    private OAuth2UserPrincipal userPrincipal;
     private DroniUser testUser;
+    private OAuth2UserPrincipal testPrincipal;
 
     @BeforeEach
     void setUp() {
-        Map<String, Object> attributes = Map.of("response",
-                Map.of("id", "test-naver-id", "email", "test@naver.com", "name", "test-user",
-                        "nickname", "test-nickname", "profile_image", "test-image-url"));
-        userPrincipal = new OAuth2UserPrincipal(new NaverOAuth2UserInfo("test-token", attributes));
-        testUser = DroniUser.builder().userId(1L).oauthId("test-naver-id").build();
+        Long oauthId = 1L;
+        testUser = DroniUser.builder()
+            .userId(oauthId)
+            .oauthId(String.valueOf(oauthId))
+            .build();
+
+        // 네이버 OAuth2 응답 구조에 맞게 response 객체 안에 사용자 정보를 넣습니다
+        Map<String, Object> response = new java.util.HashMap<>();
+        response.put("id", String.valueOf(oauthId));
+        response.put("email", "test@naver.com");
+        response.put("name", "테스트유저");
+        response.put("nickname", "테스트유저");
+
+        Map<String, Object> attributes = new java.util.HashMap<>();
+        attributes.put("response", response);
+
+        NaverOAuth2UserInfo userInfo = new NaverOAuth2UserInfo("dummy-token", attributes);
+        testPrincipal = new OAuth2UserPrincipal(userInfo);
     }
 
     @Test
-    @DisplayName("주소 저장 요청을 보내면, 저장된 주소 정보를 반환한다.")
-    void saveAddress() {
-        // given
+    void contextLoads() {
+        // 기본 설정 테스트
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/addresses - 주소지 생성 성공")
+    void saveAddress_success() throws Exception {
+        // Given
         AddressSaveRequest request = new AddressSaveRequest();
-        UserAddress savedAddress =
-                new UserAddress(1L, "test-address", false, null, null, null, null, testUser);
-        when(droniUserRepository.findByOauthId("test-naver-id")).thenReturn(Optional.of(testUser));
-        when(addressService.saveAddress(1L, request)).thenReturn(savedAddress);
+        request.setAddressName("테스트 주소");
+        request.setRecipientName("홍길동");
+        request.setContactNumber("010-1234-5678");
+        request.setAddress1("서울시 강남구");
+        request.setAddress2("101호");
+        request.setPrimary(true);
 
-        // when
-        ResponseEntity<AddressResponse> response =
-                addressController.saveAddress(userPrincipal, request);
+        UserAddress savedAddress = UserAddress.builder()
+            .addressName("테스트 주소")
+            .isPrimary(true)
+            .recipientName("홍길동")
+            .contactNumber("010-1234-5678")
+            .address1("서울시 강남구")
+            .address2("101호")
+            .user(testUser)
+            .build();
 
-        // then
-        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getAddressId()).isEqualTo(1L);
-        assertThat(response.getBody().getAddressName()).isEqualTo("test-address");
-        verify(addressService, times(1)).saveAddress(1L, request);
-    }
+        try {
+            var createdAtField = UserAddress.class.getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(savedAddress, LocalDateTime.now());
+            var updatedAtField = UserAddress.class.getDeclaredField("updatedAt");
+            updatedAtField.setAccessible(true);
+            updatedAtField.set(savedAddress, LocalDateTime.now());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
 
-    @Test
-    @DisplayName("주소 목록 조회 요청을 보내면, 해당 유저의 주소 목록을 반환한다.")
-    void getUserAddresses() {
-        // given
-        when(droniUserRepository.findByOauthId("test-naver-id")).thenReturn(Optional.of(testUser));
-        when(addressService.getUserAddresses(1L))
-                .thenReturn(List.of(UserAddress.builder().build()));
+        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
+            .thenReturn(Optional.of(testUser));
+        when(addressService.saveAddress(eq(testUser.getUserId()), any(AddressSaveRequest.class)))
+            .thenReturn(savedAddress);
 
-        // when
-        ResponseEntity<List<AddressResponse>> response =
-                addressController.getUserAddresses(userPrincipal);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
 
-        // then
-        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(response.getBody()).hasSize(1);
+        // When & Then
+        mockMvc.perform(post("/api/v1/addresses")
+                .principal(authentication)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(authentication(authentication))
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.addressName").value("테스트 주소"))
+            .andExpect(jsonPath("$.recipientName").value("홍길동"))
+            .andExpect(jsonPath("$.contactNumber").value("010-1234-5678"))
+            .andExpect(jsonPath("$.address1").value("서울시 강남구"))
+            .andExpect(jsonPath("$.address2").value("101호"))
+            .andExpect(jsonPath("$.primary").value(true))
+            .andExpect(jsonPath("$.createdAt").isNotEmpty())
+            .andExpect(jsonPath("$.updatedAt").isNotEmpty());
+
+        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
+        verify(addressService).saveAddress(eq(testUser.getUserId()), any(AddressSaveRequest.class));
     }
 }

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -125,15 +125,15 @@ class AddressControllerTest {
         // Given
         AddressSaveRequest request = createAddressSaveRequest();
 
-        UserAddress savedAddress = UserAddress.builder()
-            .addressName(request.getAddressName())
-            .isPrimary(request.isPrimary())
-            .recipientName(request.getRecipientName())
-            .contactNumber(request.getContactNumber())
-            .address1(request.getAddress1())
-            .address2(request.getAddress2())
-            .user(testUser)
-            .build();
+        UserAddress savedAddress = UserAddress.create(
+            request.getAddressName(),
+            request.isPrimary(),
+            request.getRecipientName(),
+            request.getContactNumber(),
+            request.getAddress1(),
+            request.getAddress2(),
+            testUser
+        );
 
         setAuditFields(savedAddress, LocalDateTime.now());
 
@@ -196,24 +196,24 @@ class AddressControllerTest {
     @DisplayName("GET /api/v1/addresses - 주소지 목록 조회 성공")
     void getUserAddresses_success() throws Exception {
         // Given
-        UserAddress address1 = UserAddress.builder()
-            .addressName("집")
-            .isPrimary(true)
-            .recipientName("홍길동")
-            .contactNumber("010-1111-2222")
-            .address1("서울시 강남구")
-            .address2("101호")
-            .user(testUser)
-            .build();
-        UserAddress address2 = UserAddress.builder()
-            .addressName("회사")
-            .isPrimary(false)
-            .recipientName("홍길동")
-            .contactNumber("010-3333-4444")
-            .address1("서울시 서초구")
-            .address2("202호")
-            .user(testUser)
-            .build();
+        UserAddress address1 = UserAddress.create(
+            "집",
+            true,
+            "홍길동",
+            "010-1111-2222",
+            "서울시 강남구",
+            "101호",
+            testUser
+        );
+        UserAddress address2 = UserAddress.create(
+            "회사",
+            false,
+            "홍길동",
+            "010-3333-4444",
+            "서울시 서초구",
+            "202호",
+            testUser
+        );
 
         var now = LocalDateTime.now();
         setAuditFields(address1, now);

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -5,7 +5,7 @@ import droni.backend.api.address.dto.AddressSaveRequest;
 import droni.backend.api.address.entity.UserAddress;
 import droni.backend.api.address.service.AddressService;
 import droni.backend.api.droniuser.entity.DroniUser;
-import droni.backend.api.droniuser.repository.DroniUserRepository;
+import droni.backend.global.exception.DroniNotFoundException;
 import droni.backend.oauth2.jwt.TokenAuthenticationFilter;
 import droni.backend.oauth2.service.OAuth2UserPrincipal;
 import droni.backend.oauth2.user.impl.NaverOAuth2UserInfo;
@@ -13,21 +13,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -40,8 +40,11 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 @WebMvcTest(
     controllers = AddressController.class,
     excludeFilters = {
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = TokenAuthenticationFilter.class),
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = org.springframework.data.jpa.mapping.JpaMetamodelMappingContext.class)
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = TokenAuthenticationFilter.class)
+    },
+    excludeAutoConfiguration = {
+        JpaRepositoriesAutoConfiguration.class,
+        DataSourceAutoConfiguration.class
     }
 )
 class AddressControllerTest {
@@ -56,9 +59,6 @@ class AddressControllerTest {
     private AddressService addressService;
 
     @MockBean
-    private DroniUserRepository droniUserRepository;
-
-    @MockBean
     private org.springframework.data.jpa.mapping.JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     private DroniUser testUser;
@@ -66,15 +66,15 @@ class AddressControllerTest {
 
     @BeforeEach
     void setUp() {
-        Long oauthId = 1L;
+        long userId = 1L;
+        String oauthId = "test-oauth-id";
         testUser = DroniUser.builder()
-            .userId(oauthId)
-            .oauthId(String.valueOf(oauthId))
+            .userId(userId)
+            .oauthId(oauthId)
             .build();
 
-        // 네이버 OAuth2 응답 구조에 맞게 response 객체 안에 사용자 정보를 넣습니다
         Map<String, Object> response = new java.util.HashMap<>();
-        response.put("id", String.valueOf(oauthId));
+        response.put("id", oauthId);
         response.put("email", "test@naver.com");
         response.put("name", "테스트유저");
         response.put("nickname", "테스트유저");
@@ -115,31 +115,17 @@ class AddressControllerTest {
     }
 
     @Test
-    void contextLoads() {
-        // 기본 설정 테스트
-    }
-
-    @Test
     @DisplayName("POST /api/v1/addresses - 주소지 생성 성공")
     void saveAddress_success() throws Exception {
         // Given
         AddressSaveRequest request = createAddressSaveRequest();
-
         UserAddress savedAddress = UserAddress.create(
-            request.getAddressName(),
-            request.isPrimary(),
-            request.getRecipientName(),
-            request.getContactNumber(),
-            request.getAddress1(),
-            request.getAddress2(),
-            testUser
+            request.getAddressName(), request.isPrimary(), request.getRecipientName(),
+            request.getContactNumber(), request.getAddress1(), request.getAddress2(), testUser
         );
-
         setAuditFields(savedAddress, LocalDateTime.now());
 
-        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
-            .thenReturn(Optional.of(testUser));
-        when(addressService.saveAddress(eq(testUser.getUserId()), any(AddressSaveRequest.class)))
+        when(addressService.saveAddress(any(OAuth2UserPrincipal.class), any(AddressSaveRequest.class)))
             .thenReturn(savedAddress);
 
         TestingAuthenticationToken authentication = createAuthToken();
@@ -151,18 +137,11 @@ class AddressControllerTest {
                 .content(objectMapper.writeValueAsString(request))
                 .with(authentication(authentication))
                 .with(csrf()))
-            .andExpect(status().isOk())
+            .andExpect(status().isCreated())
             .andExpect(jsonPath("$.addressName").value("테스트 주소"))
-            .andExpect(jsonPath("$.recipientName").value("홍길동"))
-            .andExpect(jsonPath("$.contactNumber").value("010-1234-5678"))
-            .andExpect(jsonPath("$.address1").value("서울시 강남구"))
-            .andExpect(jsonPath("$.address2").value("101호"))
-            .andExpect(jsonPath("$.primary").value(true))
-            .andExpect(jsonPath("$.createdAt").isNotEmpty())
-            .andExpect(jsonPath("$.updatedAt").isNotEmpty());
+            .andExpect(jsonPath("$.recipientName").value("홍길동"));
 
-        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
-        verify(addressService).saveAddress(eq(testUser.getUserId()), any(AddressSaveRequest.class));
+        verify(addressService).saveAddress(any(OAuth2UserPrincipal.class), any(AddressSaveRequest.class));
     }
 
     @Test
@@ -170,58 +149,33 @@ class AddressControllerTest {
     void saveAddress_userNotFound_shouldReturn404() throws Exception {
         // Given
         AddressSaveRequest request = createAddressSaveRequest();
-
-        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
-                .thenReturn(Optional.empty());
+        when(addressService.saveAddress(any(OAuth2UserPrincipal.class), any(AddressSaveRequest.class)))
+            .thenThrow(new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
 
         TestingAuthenticationToken authentication = createAuthToken();
 
         // When & Then
-        mockMvc.perform(post("/api/v1/addresses").principal(authentication)
+        mockMvc.perform(post("/api/v1/addresses")
+                .principal(authentication)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .with(authentication(authentication)).with(csrf()))
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.error").value("유저를 찾을 수 없습니다."))
-            .andExpect(jsonPath("$.exception").value("DroniNotFoundException"))
-            .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
-            .andExpect(jsonPath("$.path").value("/api/v1/addresses"))
-            .andExpect(jsonPath("$.timestamp").isNotEmpty());
+            .andExpect(jsonPath("$.error").value("유저를 찾을 수 없습니다."));
 
-        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
-        // AddressService.saveAddress는 호출되지 않아야 함
+        verify(addressService).saveAddress(any(OAuth2UserPrincipal.class), any(AddressSaveRequest.class));
     }
 
     @Test
     @DisplayName("GET /api/v1/addresses - 주소지 목록 조회 성공")
     void getUserAddresses_success() throws Exception {
         // Given
-        UserAddress address1 = UserAddress.create(
-            "집",
-            true,
-            "홍길동",
-            "010-1111-2222",
-            "서울시 강남구",
-            "101호",
-            testUser
-        );
-        UserAddress address2 = UserAddress.create(
-            "회사",
-            false,
-            "홍길동",
-            "010-3333-4444",
-            "서울시 서초구",
-            "202호",
-            testUser
-        );
+        UserAddress address1 = UserAddress.create("집", true, "홍길동", "010-1111-2222", "서울시 강남구", "101호", testUser);
+        UserAddress address2 = UserAddress.create("회사", false, "홍길동", "010-3333-4444", "서울시 서초구", "202호", testUser);
+        setAuditFields(address1, LocalDateTime.now());
+        setAuditFields(address2, LocalDateTime.now());
 
-        var now = LocalDateTime.now();
-        setAuditFields(address1, now);
-        setAuditFields(address2, now);
-
-        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
-            .thenReturn(Optional.of(testUser));
-        when(addressService.getUserAddresses(testUser.getUserId()))
+        when(addressService.getUserAddresses(any(OAuth2UserPrincipal.class)))
             .thenReturn(java.util.List.of(address1, address2));
 
         TestingAuthenticationToken authentication = createAuthToken();
@@ -233,24 +187,16 @@ class AddressControllerTest {
                 .with(csrf()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.length()").value(2))
-            .andExpect(jsonPath("$[0].addressName").value("집"))
-            .andExpect(jsonPath("$[0].primary").value(true))
-            .andExpect(jsonPath("$[0].createdAt").isNotEmpty())
-            .andExpect(jsonPath("$[1].addressName").value("회사"))
-            .andExpect(jsonPath("$[1].primary").value(false))
-            .andExpect(jsonPath("$[1].createdAt").isNotEmpty());
+            .andExpect(jsonPath("$[0].addressName").value("집"));
 
-        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
-        verify(addressService).getUserAddresses(testUser.getUserId());
+        verify(addressService).getUserAddresses(any(OAuth2UserPrincipal.class));
     }
 
     @Test
     @DisplayName("GET /api/v1/addresses - 주소지가 없는 경우 빈 리스트 반환")
     void getUserAddresses_emptyList() throws Exception {
         // Given
-        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
-            .thenReturn(Optional.of(testUser));
-        when(addressService.getUserAddresses(testUser.getUserId()))
+        when(addressService.getUserAddresses(any(OAuth2UserPrincipal.class)))
             .thenReturn(java.util.Collections.emptyList());
 
         TestingAuthenticationToken authentication = createAuthToken();
@@ -263,16 +209,15 @@ class AddressControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.length()").value(0));
 
-        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
-        verify(addressService).getUserAddresses(testUser.getUserId());
+        verify(addressService).getUserAddresses(any(OAuth2UserPrincipal.class));
     }
 
     @Test
     @DisplayName("GET /api/v1/addresses - 인증 정보에 해당하는 사용자를 찾을 수 없을 때 404 반환")
     void getUserAddresses_userNotFound_shouldReturn404() throws Exception {
         // Given
-        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
-            .thenReturn(Optional.empty());
+        when(addressService.getUserAddresses(any(OAuth2UserPrincipal.class)))
+            .thenThrow(new DroniNotFoundException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
 
         TestingAuthenticationToken authentication = createAuthToken();
 
@@ -282,13 +227,8 @@ class AddressControllerTest {
                 .with(authentication(authentication))
                 .with(csrf()))
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.error").value("유저를 찾을 수 없습니다."))
-            .andExpect(jsonPath("$.exception").value("DroniNotFoundException"))
-            .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
-            .andExpect(jsonPath("$.path").value("/api/v1/addresses"))
-            .andExpect(jsonPath("$.timestamp").isNotEmpty());
+            .andExpect(jsonPath("$.error").value("유저를 찾을 수 없습니다."));
 
-        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
-        verify(addressService, never()).getUserAddresses(any(Long.class));
+        verify(addressService).getUserAddresses(any(OAuth2UserPrincipal.class));
     }
 }

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -1,0 +1,89 @@
+package droni.backend.api.address.controller;
+
+import droni.backend.api.address.dto.AddressResponse;
+import droni.backend.api.address.dto.AddressSaveRequest;
+import droni.backend.api.address.entity.UserAddress;
+import droni.backend.api.address.service.AddressService;
+import droni.backend.api.droniuser.entity.DroniUser;
+import droni.backend.api.droniuser.repository.DroniUserRepository;
+import droni.backend.oauth2.service.OAuth2UserPrincipal;
+import droni.backend.oauth2.user.impl.NaverOAuth2UserInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AddressControllerTest {
+
+    @Mock
+    private AddressService addressService;
+
+    @Mock
+    private DroniUserRepository droniUserRepository;
+
+    @InjectMocks
+    private AddressController addressController;
+
+    private OAuth2UserPrincipal userPrincipal;
+    private DroniUser testUser;
+
+    @BeforeEach
+    void setUp() {
+        Map<String, Object> attributes = Map.of("response",
+                Map.of("id", "test-naver-id", "email", "test@naver.com", "name", "test-user",
+                        "nickname", "test-nickname", "profile_image", "test-image-url"));
+        userPrincipal = new OAuth2UserPrincipal(new NaverOAuth2UserInfo("test-token", attributes));
+        testUser = DroniUser.builder().userId(1L).oauthId("test-naver-id").build();
+    }
+
+    @Test
+    @DisplayName("주소 저장 요청을 보내면, 저장된 주소 정보를 반환한다.")
+    void saveAddress() {
+        // given
+        AddressSaveRequest request = new AddressSaveRequest();
+        UserAddress savedAddress =
+                new UserAddress(1L, "test-address", false, null, null, null, null, testUser);
+        when(droniUserRepository.findByOauthId("test-naver-id")).thenReturn(Optional.of(testUser));
+        when(addressService.saveAddress(1L, request)).thenReturn(savedAddress);
+
+        // when
+        ResponseEntity<AddressResponse> response =
+                addressController.saveAddress(userPrincipal, request);
+
+        // then
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getAddressId()).isEqualTo(1L);
+        assertThat(response.getBody().getAddressName()).isEqualTo("test-address");
+        verify(addressService, times(1)).saveAddress(1L, request);
+    }
+
+    @Test
+    @DisplayName("주소 목록 조회 요청을 보내면, 해당 유저의 주소 목록을 반환한다.")
+    void getUserAddresses() {
+        // given
+        when(droniUserRepository.findByOauthId("test-naver-id")).thenReturn(Optional.of(testUser));
+        when(addressService.getUserAddresses(1L))
+                .thenReturn(List.of(UserAddress.builder().build()));
+
+        // when
+        ResponseEntity<List<AddressResponse>> response =
+                addressController.getUserAddresses(userPrincipal);
+
+        // then
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).hasSize(1);
+    }
+}

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -27,8 +27,10 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -181,5 +183,112 @@ class AddressControllerTest {
 
         verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
         // AddressService.saveAddress는 호출되지 않아야 함
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/addresses - 주소지 목록 조회 성공")
+    void getUserAddresses_success() throws Exception {
+        // Given
+        UserAddress address1 = UserAddress.builder()
+            .addressName("집")
+            .isPrimary(true)
+            .recipientName("홍길동")
+            .contactNumber("010-1111-2222")
+            .address1("서울시 강남구")
+            .address2("101호")
+            .user(testUser)
+            .build();
+        UserAddress address2 = UserAddress.builder()
+            .addressName("회사")
+            .isPrimary(false)
+            .recipientName("홍길동")
+            .contactNumber("010-3333-4444")
+            .address1("서울시 서초구")
+            .address2("202호")
+            .user(testUser)
+            .build();
+
+        // createdAt/updatedAt 필드 설정
+        var now = LocalDateTime.now();
+        for (UserAddress addr : new UserAddress[]{address1, address2}) {
+            var createdAtField = UserAddress.class.getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(addr, now);
+            var updatedAtField = UserAddress.class.getDeclaredField("updatedAt");
+            updatedAtField.setAccessible(true);
+            updatedAtField.set(addr, now);
+        }
+
+        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
+            .thenReturn(Optional.of(testUser));
+        when(addressService.getUserAddresses(testUser.getUserId()))
+            .thenReturn(java.util.List.of(address1, address2));
+
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/addresses")
+                .principal(authentication)
+                .with(authentication(authentication))
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[0].addressName").value("집"))
+            .andExpect(jsonPath("$[0].primary").value(true))
+            .andExpect(jsonPath("$[0].createdAt").isNotEmpty())
+            .andExpect(jsonPath("$[1].addressName").value("회사"))
+            .andExpect(jsonPath("$[1].primary").value(false))
+            .andExpect(jsonPath("$[1].createdAt").isNotEmpty());
+
+        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
+        verify(addressService).getUserAddresses(testUser.getUserId());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/addresses - 주소지가 없는 경우 빈 리스트 반환")
+    void getUserAddresses_emptyList() throws Exception {
+        // Given
+        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
+            .thenReturn(Optional.of(testUser));
+        when(addressService.getUserAddresses(testUser.getUserId()))
+            .thenReturn(java.util.Collections.emptyList());
+
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/addresses")
+                .principal(authentication)
+                .with(authentication(authentication))
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(0));
+
+        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
+        verify(addressService).getUserAddresses(testUser.getUserId());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/addresses - 인증 정보에 해당하는 사용자를 찾을 수 없을 때 404 반환")
+    void getUserAddresses_userNotFound_shouldReturn404() throws Exception {
+        // Given
+        when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
+            .thenReturn(Optional.empty());
+
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/addresses")
+                .principal(authentication)
+                .with(authentication(authentication))
+                .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("유저를 찾을 수 없습니다."))
+            .andExpect(jsonPath("$.exception").value("DroniNotFoundException"))
+            .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
+            .andExpect(jsonPath("$.path").value("/api/v1/addresses"))
+            .andExpect(jsonPath("$.timestamp").isNotEmpty());
+
+        verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
+        verify(addressService, never()).getUserAddresses(any(Long.class));
     }
 }

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -25,17 +25,20 @@ import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 
 @WebMvcTest(
     controllers = AddressController.class,
@@ -101,19 +104,6 @@ class AddressControllerTest {
         return new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
     }
 
-    private void setAuditFields(UserAddress address, LocalDateTime time) {
-        try {
-            var createdAtField = UserAddress.class.getDeclaredField("createdAt");
-            createdAtField.setAccessible(true);
-            createdAtField.set(address, time);
-            var updatedAtField = UserAddress.class.getDeclaredField("updatedAt");
-            updatedAtField.setAccessible(true);
-            updatedAtField.set(address, time);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Test
     @DisplayName("POST /api/v1/addresses - 주소지 생성 성공")
     void saveAddress_success() throws Exception {
@@ -123,7 +113,9 @@ class AddressControllerTest {
             request.getAddressName(), request.getIsPrimary(), request.getRecipientName(),
             request.getContactNumber(), request.getAddress1(), request.getAddress2(), testUser
         );
-        setAuditFields(savedAddress, LocalDateTime.now());
+        LocalDateTime now = LocalDateTime.now();
+        doReturn(now).when(savedAddress).getCreatedAt();
+        doReturn(now).when(savedAddress).getUpdatedAt();
 
         when(addressService.saveAddress(any(OAuth2UserPrincipal.class), any(AddressSaveRequest.class)))
             .thenReturn(savedAddress);
@@ -170,13 +162,16 @@ class AddressControllerTest {
     @DisplayName("GET /api/v1/addresses - 주소지 목록 조회 성공")
     void getUserAddresses_success() throws Exception {
         // Given
+        LocalDateTime now = LocalDateTime.now();
         UserAddress address1 = UserAddress.create("집", true, "홍길동", "010-1111-2222", "서울시 강남구", "101호", testUser);
         UserAddress address2 = UserAddress.create("회사", false, "홍길동", "010-3333-4444", "서울시 서초구", "202호", testUser);
-        setAuditFields(address1, LocalDateTime.now());
-        setAuditFields(address2, LocalDateTime.now());
+        doReturn(now).when(address1).getCreatedAt();
+        doReturn(now).when(address1).getUpdatedAt();
+        doReturn(now).when(address2).getCreatedAt();
+        doReturn(now).when(address2).getUpdatedAt();
 
         when(addressService.getUserAddresses(any(OAuth2UserPrincipal.class)))
-            .thenReturn(java.util.List.of(address1, address2));
+            .thenReturn(List.of(address1, address2));
 
         TestingAuthenticationToken authentication = createAuthToken();
 
@@ -197,7 +192,7 @@ class AddressControllerTest {
     void getUserAddresses_emptyList() throws Exception {
         // Given
         when(addressService.getUserAddresses(any(OAuth2UserPrincipal.class)))
-            .thenReturn(java.util.Collections.emptyList());
+            .thenReturn(Collections.emptyList());
 
         TestingAuthenticationToken authentication = createAuthToken();
 

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -86,6 +86,34 @@ class AddressControllerTest {
         testPrincipal = new OAuth2UserPrincipal(userInfo);
     }
 
+    private AddressSaveRequest createAddressSaveRequest() {
+        AddressSaveRequest request = new AddressSaveRequest();
+        request.setAddressName("테스트 주소");
+        request.setRecipientName("홍길동");
+        request.setContactNumber("010-1234-5678");
+        request.setAddress1("서울시 강남구");
+        request.setAddress2("101호");
+        request.setPrimary(true);
+        return request;
+    }
+
+    private TestingAuthenticationToken createAuthToken() {
+        return new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+    }
+
+    private void setAuditFields(UserAddress address, LocalDateTime time) {
+        try {
+            var createdAtField = UserAddress.class.getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(address, time);
+            var updatedAtField = UserAddress.class.getDeclaredField("updatedAt");
+            updatedAtField.setAccessible(true);
+            updatedAtField.set(address, time);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     void contextLoads() {
         // 기본 설정 테스트
@@ -95,41 +123,26 @@ class AddressControllerTest {
     @DisplayName("POST /api/v1/addresses - 주소지 생성 성공")
     void saveAddress_success() throws Exception {
         // Given
-        AddressSaveRequest request = new AddressSaveRequest();
-        request.setAddressName("테스트 주소");
-        request.setRecipientName("홍길동");
-        request.setContactNumber("010-1234-5678");
-        request.setAddress1("서울시 강남구");
-        request.setAddress2("101호");
-        request.setPrimary(true);
+        AddressSaveRequest request = createAddressSaveRequest();
 
         UserAddress savedAddress = UserAddress.builder()
-            .addressName("테스트 주소")
-            .isPrimary(true)
-            .recipientName("홍길동")
-            .contactNumber("010-1234-5678")
-            .address1("서울시 강남구")
-            .address2("101호")
+            .addressName(request.getAddressName())
+            .isPrimary(request.isPrimary())
+            .recipientName(request.getRecipientName())
+            .contactNumber(request.getContactNumber())
+            .address1(request.getAddress1())
+            .address2(request.getAddress2())
             .user(testUser)
             .build();
 
-        try {
-            var createdAtField = UserAddress.class.getDeclaredField("createdAt");
-            createdAtField.setAccessible(true);
-            createdAtField.set(savedAddress, LocalDateTime.now());
-            var updatedAtField = UserAddress.class.getDeclaredField("updatedAt");
-            updatedAtField.setAccessible(true);
-            updatedAtField.set(savedAddress, LocalDateTime.now());
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        setAuditFields(savedAddress, LocalDateTime.now());
 
         when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
             .thenReturn(Optional.of(testUser));
         when(addressService.saveAddress(eq(testUser.getUserId()), any(AddressSaveRequest.class)))
             .thenReturn(savedAddress);
 
-        TestingAuthenticationToken authentication = new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+        TestingAuthenticationToken authentication = createAuthToken();
 
         // When & Then
         mockMvc.perform(post("/api/v1/addresses")
@@ -156,30 +169,24 @@ class AddressControllerTest {
     @DisplayName("POST /api/v1/addresses - 인증 정보에 해당하는 사용자를 찾을 수 없을 때 404 반환")
     void saveAddress_userNotFound_shouldReturn404() throws Exception {
         // Given
-        AddressSaveRequest request = new AddressSaveRequest();
-        request.setAddressName("테스트 주소");
-        request.setRecipientName("홍길동");
-        request.setContactNumber("010-1234-5678");
-        request.setAddress1("서울시 강남구");
-        request.setAddress2("101호");
-        request.setPrimary(true);
+        AddressSaveRequest request = createAddressSaveRequest();
 
         when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
                 .thenReturn(Optional.empty());
 
-        TestingAuthenticationToken authentication =
-                new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+        TestingAuthenticationToken authentication = createAuthToken();
 
         // When & Then
         mockMvc.perform(post("/api/v1/addresses").principal(authentication)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
-                .with(authentication(authentication)).with(csrf())).andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("유저를 찾을 수 없습니다."))
-                .andExpect(jsonPath("$.exception").value("DroniNotFoundException"))
-                .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
-                .andExpect(jsonPath("$.path").value("/api/v1/addresses"))
-                .andExpect(jsonPath("$.timestamp").isNotEmpty());
+                .with(authentication(authentication)).with(csrf()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("유저를 찾을 수 없습니다."))
+            .andExpect(jsonPath("$.exception").value("DroniNotFoundException"))
+            .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
+            .andExpect(jsonPath("$.path").value("/api/v1/addresses"))
+            .andExpect(jsonPath("$.timestamp").isNotEmpty());
 
         verify(droniUserRepository).findByOauthId(testPrincipal.getOAuth2Id());
         // AddressService.saveAddress는 호출되지 않아야 함
@@ -208,23 +215,16 @@ class AddressControllerTest {
             .user(testUser)
             .build();
 
-        // createdAt/updatedAt 필드 설정
         var now = LocalDateTime.now();
-        for (UserAddress addr : new UserAddress[]{address1, address2}) {
-            var createdAtField = UserAddress.class.getDeclaredField("createdAt");
-            createdAtField.setAccessible(true);
-            createdAtField.set(addr, now);
-            var updatedAtField = UserAddress.class.getDeclaredField("updatedAt");
-            updatedAtField.setAccessible(true);
-            updatedAtField.set(addr, now);
-        }
+        setAuditFields(address1, now);
+        setAuditFields(address2, now);
 
         when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
             .thenReturn(Optional.of(testUser));
         when(addressService.getUserAddresses(testUser.getUserId()))
             .thenReturn(java.util.List.of(address1, address2));
 
-        TestingAuthenticationToken authentication = new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+        TestingAuthenticationToken authentication = createAuthToken();
 
         // When & Then
         mockMvc.perform(get("/api/v1/addresses")
@@ -253,7 +253,7 @@ class AddressControllerTest {
         when(addressService.getUserAddresses(testUser.getUserId()))
             .thenReturn(java.util.Collections.emptyList());
 
-        TestingAuthenticationToken authentication = new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+        TestingAuthenticationToken authentication = createAuthToken();
 
         // When & Then
         mockMvc.perform(get("/api/v1/addresses")
@@ -274,7 +274,7 @@ class AddressControllerTest {
         when(droniUserRepository.findByOauthId(testPrincipal.getOAuth2Id()))
             .thenReturn(Optional.empty());
 
-        TestingAuthenticationToken authentication = new TestingAuthenticationToken(testPrincipal, null, "ROLE_USER");
+        TestingAuthenticationToken authentication = createAuthToken();
 
         // When & Then
         mockMvc.perform(get("/api/v1/addresses")

--- a/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
+++ b/src/test/java/droni/backend/api/address/controller/AddressControllerTest.java
@@ -93,7 +93,7 @@ class AddressControllerTest {
         request.setContactNumber("010-1234-5678");
         request.setAddress1("서울시 강남구");
         request.setAddress2("101호");
-        request.setPrimary(true);
+        request.setIsPrimary(true);
         return request;
     }
 
@@ -120,7 +120,7 @@ class AddressControllerTest {
         // Given
         AddressSaveRequest request = createAddressSaveRequest();
         UserAddress savedAddress = UserAddress.create(
-            request.getAddressName(), request.isPrimary(), request.getRecipientName(),
+            request.getAddressName(), request.getIsPrimary(), request.getRecipientName(),
             request.getContactNumber(), request.getAddress1(), request.getAddress2(), testUser
         );
         setAuditFields(savedAddress, LocalDateTime.now());

--- a/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
+++ b/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
@@ -49,7 +49,9 @@ class AddressServiceTest {
 
     @BeforeEach
     void setUp() {
-        testUser = DroniUser.builder().userId(userId).build();
+        testUser = DroniUser.builder()
+            .userId(userId)
+            .build();
     }
 
     @Test
@@ -76,8 +78,12 @@ class AddressServiceTest {
     void saveAddress_newPrimaryShouldDemoteOldPrimary() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(true);
-        UserAddress oldPrimaryAddress = UserAddress.builder().user(testUser).isPrimary(true).build();
-        UserAddress otherAddress = UserAddress.builder().user(testUser).isPrimary(false).build();
+        UserAddress oldPrimaryAddress = UserAddress.create(
+            "oldPrimary", true, "홍길동", "010-1111-2222", "서울시", "강남구", testUser
+        );
+        UserAddress otherAddress = UserAddress.create(
+            "other", false, "김철수", "010-3333-4444", "부산시", "해운대구", testUser
+        );
 
         when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(oldPrimaryAddress, otherAddress));
@@ -100,7 +106,9 @@ class AddressServiceTest {
     void saveAddress_nonPrimaryShouldRemainNonPrimaryIfPrimaryExists() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
-        UserAddress existingPrimaryAddress = UserAddress.builder().user(testUser).isPrimary(true).build();
+        UserAddress existingPrimaryAddress = UserAddress.create(
+            "기본주소", true, "홍길동", "010-1234-5678", "서울시", "강남구", testUser
+        );
 
         when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(existingPrimaryAddress));
@@ -122,7 +130,9 @@ class AddressServiceTest {
     void saveAddress_shouldBecomePrimaryIfNoPrimaryExists() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
-        UserAddress nonPrimaryAddress = UserAddress.builder().user(testUser).isPrimary(false).build();
+        UserAddress nonPrimaryAddress = UserAddress.create(
+            "일반주소", false, "김철수", "010-9876-5432", "부산시", "해운대구", testUser
+        );
 
         when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(nonPrimaryAddress));
@@ -156,8 +166,8 @@ class AddressServiceTest {
     void getUserAddresses_shouldReturnAddressList() {
         // given
         List<UserAddress> expectedAddresses = List.of(
-            UserAddress.builder().build(),
-            UserAddress.builder().build()
+            UserAddress.create("주소1", true, "홍길동", "010-1234-5678", "서울시", "강남구", testUser),
+            UserAddress.create("주소2", false, "김철수", "010-9876-5432", "부산시", "해운대구", testUser)
         );
         when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(expectedAddresses);

--- a/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
+++ b/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
@@ -5,6 +5,7 @@ import droni.backend.api.address.entity.UserAddress;
 import droni.backend.api.address.repository.UserAddressRepository;
 import droni.backend.api.droniuser.entity.DroniUser;
 import droni.backend.api.droniuser.repository.DroniUserRepository;
+import droni.backend.global.exception.DroniNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -152,5 +154,36 @@ class AddressServiceTest {
 
         // then
         assertThat(userAddresses).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("주소 저장 - 사용자를 찾을 수 없으면 DroniNotFoundException 발생")
+    void saveAddress_throwsDroniNotFoundException_whenUserNotFound() {
+        // given
+        long userId = 1L;
+        AddressSaveRequest saveRequest = createSaveRequest(true);
+        when(droniUserRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(DroniNotFoundException.class, () -> {
+            addressService.saveAddress(userId, saveRequest);
+        });
+
+        verify(userAddressRepository, never()).save(any(UserAddress.class));
+    }
+
+    @Test
+    @DisplayName("주소 목록 조회 - 사용자를 찾을 수 없으면 DroniNotFoundException 발생")
+    void getUserAddresses_throwsDroniNotFoundException_whenUserNotFound() {
+        // given
+        long userId = 1L;
+        when(droniUserRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(DroniNotFoundException.class, () -> {
+            addressService.getUserAddresses(userId);
+        });
+
+        verify(userAddressRepository, never()).findByUser(any(DroniUser.class));
     }
 }

--- a/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
+++ b/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
@@ -51,7 +51,7 @@ class AddressServiceTest {
         request.setContactNumber("010-0000-0000");
         request.setAddress1("테스트 주소1");
         request.setAddress2("테스트 주소2");
-        request.setPrimary(isPrimary);
+        request.setIsPrimary(isPrimary);
         return request;
     }
 

--- a/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
+++ b/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
@@ -1,0 +1,156 @@
+package droni.backend.api.address.service;
+
+import droni.backend.api.address.dto.AddressSaveRequest;
+import droni.backend.api.address.entity.UserAddress;
+import droni.backend.api.address.repository.UserAddressRepository;
+import droni.backend.api.droniuser.entity.DroniUser;
+import droni.backend.api.droniuser.repository.DroniUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AddressServiceTest {
+
+    @Mock
+    private UserAddressRepository userAddressRepository;
+
+    @Mock
+    private DroniUserRepository droniUserRepository;
+
+    @InjectMocks
+    private AddressService addressService;
+
+    private DroniUser testUser;
+
+    private AddressSaveRequest createSaveRequest(boolean isPrimary) {
+        AddressSaveRequest request = new AddressSaveRequest();
+        request.setPrimary(isPrimary);
+        return request;
+    }
+
+    @BeforeEach
+    void setUp() {
+        testUser = DroniUser.builder().userId(1L).build();
+    }
+
+    @Test
+    @DisplayName("주소 저장 - 첫 주소는 항상 기본 주소로 설정된다")
+    void saveAddress_firstAddressIsPrimary() {
+        // given
+        AddressSaveRequest saveRequest = createSaveRequest(false); // Request says not primary
+        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of()); // No existing
+                                                                                // addresses
+        when(userAddressRepository.save(any(UserAddress.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        UserAddress newAddress = addressService.saveAddress(1L, saveRequest);
+
+        // then
+        assertThat(newAddress.isPrimary()).isTrue();
+        verify(userAddressRepository, times(1)).save(any(UserAddress.class));
+    }
+
+    @Test
+    @DisplayName("주소 저장 - 새 주소가 기본 주소로 설정되면 기존 기본 주소는 해제된다")
+    void saveAddress_newPrimaryDemotesOldPrimary() {
+        // given
+        AddressSaveRequest saveRequest = createSaveRequest(true);
+        UserAddress oldPrimaryAddress =
+                UserAddress.builder().user(testUser).isPrimary(true).build();
+        UserAddress otherAddress = UserAddress.builder().user(testUser).isPrimary(false).build();
+
+        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser))
+                .thenReturn(List.of(oldPrimaryAddress, otherAddress));
+        when(userAddressRepository.save(any(UserAddress.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        UserAddress newAddress = addressService.saveAddress(1L, saveRequest);
+
+        // then
+        assertThat(newAddress.isPrimary()).isTrue();
+        assertThat(oldPrimaryAddress.isPrimary()).isFalse(); // Old primary should be demoted
+        assertThat(otherAddress.isPrimary()).isFalse(); // Other address should remain non-primary
+        verify(userAddressRepository, times(1)).save(any(UserAddress.class));
+    }
+
+    @Test
+    @DisplayName("주소 저장 - 기본 주소가 없는 상태에서 새 주소가 기본이 아니면 새 주소가 기본 주소가 된다")
+    void saveAddress_noExistingPrimaryNewNonPrimaryBecomesPrimary() {
+        // given
+        AddressSaveRequest saveRequest = createSaveRequest(false); // Request says not primary
+        UserAddress nonPrimaryAddress =
+                UserAddress.builder().user(testUser).isPrimary(false).build();
+
+        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(nonPrimaryAddress)); // No
+                                                                                                 // primary
+                                                                                                 // exists
+        when(userAddressRepository.save(any(UserAddress.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        UserAddress newAddress = addressService.saveAddress(1L, saveRequest);
+
+        // then
+        assertThat(newAddress.isPrimary()).isTrue(); // Should be promoted to primary
+        assertThat(nonPrimaryAddress.isPrimary()).isFalse();
+        verify(userAddressRepository, times(1)).save(any(UserAddress.class));
+    }
+
+    @Test
+    @DisplayName("주소 저장 - 기본 주소가 있는 상태에서 새 주소가 기본이 아니면 새 주소는 기본이 아니다")
+    void saveAddress_existingPrimaryNewNonPrimaryRemainsNonPrimary() {
+        // given
+        AddressSaveRequest saveRequest = createSaveRequest(false); // Request says not primary
+        UserAddress existingPrimaryAddress =
+                UserAddress.builder().user(testUser).isPrimary(true).build();
+        UserAddress otherAddress = UserAddress.builder().user(testUser).isPrimary(false).build();
+
+        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser))
+                .thenReturn(List.of(existingPrimaryAddress, otherAddress));
+        when(userAddressRepository.save(any(UserAddress.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        UserAddress newAddress = addressService.saveAddress(1L, saveRequest);
+
+        // then
+        assertThat(newAddress.isPrimary()).isFalse(); // Should remain non-primary
+        assertThat(existingPrimaryAddress.isPrimary()).isTrue(); // Existing primary should remain
+                                                                 // primary
+        assertThat(otherAddress.isPrimary()).isFalse();
+        verify(userAddressRepository, times(1)).save(any(UserAddress.class));
+    }
+
+    @Test
+    @DisplayName("주소 목록 조회")
+    void getUserAddresses() {
+        // given
+        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser))
+                .thenReturn(List.of(UserAddress.builder().build(), UserAddress.builder().build()));
+
+        // when
+        List<UserAddress> userAddresses = addressService.getUserAddresses(1L);
+
+        // then
+        assertThat(userAddresses).hasSize(2);
+    }
+}

--- a/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
+++ b/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
@@ -6,6 +6,7 @@ import droni.backend.api.address.repository.UserAddressRepository;
 import droni.backend.api.droniuser.entity.DroniUser;
 import droni.backend.api.droniuser.repository.DroniUserRepository;
 import droni.backend.global.exception.DroniNotFoundException;
+import droni.backend.oauth2.service.OAuth2UserPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,12 +38,17 @@ class AddressServiceTest {
     private AddressService addressService;
 
     private DroniUser testUser;
+    private OAuth2UserPrincipal testUserPrincipal;
     private final Long userId = 1L;
+    private final String oauthId = "test-oauth-id";
 
     private AddressSaveRequest createSaveRequest(boolean isPrimary) {
         AddressSaveRequest request = new AddressSaveRequest();
-        // 실제 요청처럼 필드를 설정해주는 것이 더 명확할 수 있습니다.
-        // request.setAddressName("테스트 주소");
+        request.setAddressName("테스트 주소");
+        request.setRecipientName("테스트 수령인");
+        request.setContactNumber("010-0000-0000");
+        request.setAddress1("테스트 주소1");
+        request.setAddress2("테스트 주소2");
         request.setPrimary(isPrimary);
         return request;
     }
@@ -50,8 +56,12 @@ class AddressServiceTest {
     @BeforeEach
     void setUp() {
         testUser = DroniUser.builder()
-            .userId(userId)
-            .build();
+                .userId(userId)
+                .oauthId(oauthId)
+                .build();
+
+        testUserPrincipal = mock(OAuth2UserPrincipal.class);
+        when(testUserPrincipal.getOAuth2Id()).thenReturn(oauthId);
     }
 
     @Test
@@ -59,11 +69,11 @@ class AddressServiceTest {
     void saveAddress_firstAddressShouldBePrimary() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
-        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(Collections.emptyList());
 
         // when
-        addressService.saveAddress(userId, saveRequest);
+        addressService.saveAddress(testUserPrincipal, saveRequest);
 
         // then
         ArgumentCaptor<UserAddress> addressCaptor = ArgumentCaptor.forClass(UserAddress.class);
@@ -79,17 +89,17 @@ class AddressServiceTest {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(true);
         UserAddress oldPrimaryAddress = UserAddress.create(
-            "oldPrimary", true, "홍길동", "010-1111-2222", "서울시", "강남구", testUser
+                "oldPrimary", true, "홍길동", "010-1111-2222", "서울시", "강남구", testUser
         );
         UserAddress otherAddress = UserAddress.create(
-            "other", false, "김철수", "010-3333-4444", "부산시", "해운대구", testUser
+                "other", false, "김철수", "010-3333-4444", "부산시", "해운대구", testUser
         );
 
-        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(oldPrimaryAddress, otherAddress));
 
         // when
-        addressService.saveAddress(userId, saveRequest);
+        addressService.saveAddress(testUserPrincipal, saveRequest);
 
         // then
         ArgumentCaptor<UserAddress> addressCaptor = ArgumentCaptor.forClass(UserAddress.class);
@@ -107,14 +117,14 @@ class AddressServiceTest {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
         UserAddress existingPrimaryAddress = UserAddress.create(
-            "기본주소", true, "홍길동", "010-1234-5678", "서울시", "강남구", testUser
+                "기본주소", true, "홍길동", "010-1234-5678", "서울시", "강남구", testUser
         );
 
-        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(existingPrimaryAddress));
 
         // when
-        addressService.saveAddress(userId, saveRequest);
+        addressService.saveAddress(testUserPrincipal, saveRequest);
 
         // then
         ArgumentCaptor<UserAddress> addressCaptor = ArgumentCaptor.forClass(UserAddress.class);
@@ -131,14 +141,14 @@ class AddressServiceTest {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
         UserAddress nonPrimaryAddress = UserAddress.create(
-            "일반주소", false, "김철수", "010-9876-5432", "부산시", "해운대구", testUser
+                "일반주소", false, "김철수", "010-9876-5432", "부산시", "해운대구", testUser
         );
 
-        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(nonPrimaryAddress));
 
         // when
-        addressService.saveAddress(userId, saveRequest);
+        addressService.saveAddress(testUserPrincipal, saveRequest);
 
         // then
         ArgumentCaptor<UserAddress> addressCaptor = ArgumentCaptor.forClass(UserAddress.class);
@@ -154,10 +164,10 @@ class AddressServiceTest {
     void saveAddress_shouldThrowException_whenUserNotFound() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(true);
-        when(droniUserRepository.findById(userId)).thenReturn(Optional.empty());
+        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(DroniNotFoundException.class, () -> addressService.saveAddress(userId, saveRequest));
+        assertThrows(DroniNotFoundException.class, () -> addressService.saveAddress(testUserPrincipal, saveRequest));
         verify(userAddressRepository, never()).save(any(UserAddress.class));
     }
 
@@ -166,14 +176,14 @@ class AddressServiceTest {
     void getUserAddresses_shouldReturnAddressList() {
         // given
         List<UserAddress> expectedAddresses = List.of(
-            UserAddress.create("주소1", true, "홍길동", "010-1234-5678", "서울시", "강남구", testUser),
-            UserAddress.create("주소2", false, "김철수", "010-9876-5432", "부산시", "해운대구", testUser)
+                UserAddress.create("주소1", true, "홍길동", "010-1234-5678", "서울시", "강남구", testUser),
+                UserAddress.create("주소2", false, "김철수", "010-9876-5432", "부산시", "해운대구", testUser)
         );
-        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(expectedAddresses);
 
         // when
-        List<UserAddress> actualAddresses = addressService.getUserAddresses(userId);
+        List<UserAddress> actualAddresses = addressService.getUserAddresses(testUserPrincipal);
 
         // then
         assertThat(actualAddresses).hasSize(2);
@@ -184,11 +194,11 @@ class AddressServiceTest {
     @DisplayName("GET-SUCCESS-002: 주소가 없는 사용자의 목록 조회 시, 빈 리스트 반환")
     void getUserAddresses_shouldReturnEmptyList_whenNoAddresses() {
         // given
-        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
         when(userAddressRepository.findByUser(testUser)).thenReturn(Collections.emptyList());
 
         // when
-        List<UserAddress> userAddresses = addressService.getUserAddresses(userId);
+        List<UserAddress> userAddresses = addressService.getUserAddresses(testUserPrincipal);
 
         // then
         assertThat(userAddresses).isNotNull();
@@ -199,10 +209,10 @@ class AddressServiceTest {
     @DisplayName("GET-FAIL-001: 존재하지 않는 사용자로 주소 목록 조회 시, 예외 발생")
     void getUserAddresses_shouldThrowException_whenUserNotFound() {
         // given
-        when(droniUserRepository.findById(userId)).thenReturn(Optional.empty());
+        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(DroniNotFoundException.class, () -> addressService.getUserAddresses(userId));
+        assertThrows(DroniNotFoundException.class, () -> addressService.getUserAddresses(testUserPrincipal));
         verify(userAddressRepository, never()).findByUser(any(DroniUser.class));
     }
 }

--- a/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
+++ b/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
@@ -10,10 +10,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,155 +37,162 @@ class AddressServiceTest {
     private AddressService addressService;
 
     private DroniUser testUser;
+    private final Long userId = 1L;
 
     private AddressSaveRequest createSaveRequest(boolean isPrimary) {
         AddressSaveRequest request = new AddressSaveRequest();
+        // 실제 요청처럼 필드를 설정해주는 것이 더 명확할 수 있습니다.
+        // request.setAddressName("테스트 주소");
         request.setPrimary(isPrimary);
         return request;
     }
 
     @BeforeEach
     void setUp() {
-        testUser = DroniUser.builder().userId(1L).build();
+        testUser = DroniUser.builder().userId(userId).build();
     }
 
     @Test
-    @DisplayName("주소 저장 - 첫 주소는 항상 기본 주소로 설정된다")
-    void saveAddress_firstAddressIsPrimary() {
+    @DisplayName("SAVE-SUCCESS-001: 첫 주소 저장 시, 요청과 무관하게 기본 주소로 자동 설정")
+    void saveAddress_firstAddressShouldBePrimary() {
         // given
-        AddressSaveRequest saveRequest = createSaveRequest(false); // Request says not primary
-        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of()); // No existing
-                                                                                // addresses
-        when(userAddressRepository.save(any(UserAddress.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        AddressSaveRequest saveRequest = createSaveRequest(false);
+        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser)).thenReturn(Collections.emptyList());
 
         // when
-        UserAddress newAddress = addressService.saveAddress(1L, saveRequest);
+        addressService.saveAddress(userId, saveRequest);
 
         // then
-        assertThat(newAddress.isPrimary()).isTrue();
-        verify(userAddressRepository, times(1)).save(any(UserAddress.class));
+        ArgumentCaptor<UserAddress> addressCaptor = ArgumentCaptor.forClass(UserAddress.class);
+        verify(userAddressRepository).save(addressCaptor.capture());
+        UserAddress savedAddress = addressCaptor.getValue();
+
+        assertThat(savedAddress.isPrimary()).isTrue();
     }
 
     @Test
-    @DisplayName("주소 저장 - 새 주소가 기본 주소로 설정되면 기존 기본 주소는 해제된다")
-    void saveAddress_newPrimaryDemotesOldPrimary() {
+    @DisplayName("SAVE-SUCCESS-002: 새로운 기본 주소 저장 시, 기존 기본 주소는 해제")
+    void saveAddress_newPrimaryShouldDemoteOldPrimary() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(true);
-        UserAddress oldPrimaryAddress =
-                UserAddress.builder().user(testUser).isPrimary(true).build();
+        UserAddress oldPrimaryAddress = UserAddress.builder().user(testUser).isPrimary(true).build();
         UserAddress otherAddress = UserAddress.builder().user(testUser).isPrimary(false).build();
 
-        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser))
-                .thenReturn(List.of(oldPrimaryAddress, otherAddress));
-        when(userAddressRepository.save(any(UserAddress.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(oldPrimaryAddress, otherAddress));
 
         // when
-        UserAddress newAddress = addressService.saveAddress(1L, saveRequest);
+        addressService.saveAddress(userId, saveRequest);
 
         // then
+        ArgumentCaptor<UserAddress> addressCaptor = ArgumentCaptor.forClass(UserAddress.class);
+        verify(userAddressRepository).save(addressCaptor.capture());
+        UserAddress newAddress = addressCaptor.getValue();
+
         assertThat(newAddress.isPrimary()).isTrue();
-        assertThat(oldPrimaryAddress.isPrimary()).isFalse(); // Old primary should be demoted
-        assertThat(otherAddress.isPrimary()).isFalse(); // Other address should remain non-primary
-        verify(userAddressRepository, times(1)).save(any(UserAddress.class));
-    }
-
-    @Test
-    @DisplayName("주소 저장 - 기본 주소가 없는 상태에서 새 주소가 기본이 아니면 새 주소가 기본 주소가 된다")
-    void saveAddress_noExistingPrimaryNewNonPrimaryBecomesPrimary() {
-        // given
-        AddressSaveRequest saveRequest = createSaveRequest(false); // Request says not primary
-        UserAddress nonPrimaryAddress =
-                UserAddress.builder().user(testUser).isPrimary(false).build();
-
-        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(nonPrimaryAddress)); // No
-                                                                                                 // primary
-                                                                                                 // exists
-        when(userAddressRepository.save(any(UserAddress.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        // when
-        UserAddress newAddress = addressService.saveAddress(1L, saveRequest);
-
-        // then
-        assertThat(newAddress.isPrimary()).isTrue(); // Should be promoted to primary
-        assertThat(nonPrimaryAddress.isPrimary()).isFalse();
-        verify(userAddressRepository, times(1)).save(any(UserAddress.class));
-    }
-
-    @Test
-    @DisplayName("주소 저장 - 기본 주소가 있는 상태에서 새 주소가 기본이 아니면 새 주소는 기본이 아니다")
-    void saveAddress_existingPrimaryNewNonPrimaryRemainsNonPrimary() {
-        // given
-        AddressSaveRequest saveRequest = createSaveRequest(false); // Request says not primary
-        UserAddress existingPrimaryAddress =
-                UserAddress.builder().user(testUser).isPrimary(true).build();
-        UserAddress otherAddress = UserAddress.builder().user(testUser).isPrimary(false).build();
-
-        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser))
-                .thenReturn(List.of(existingPrimaryAddress, otherAddress));
-        when(userAddressRepository.save(any(UserAddress.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        // when
-        UserAddress newAddress = addressService.saveAddress(1L, saveRequest);
-
-        // then
-        assertThat(newAddress.isPrimary()).isFalse(); // Should remain non-primary
-        assertThat(existingPrimaryAddress.isPrimary()).isTrue(); // Existing primary should remain
-                                                                 // primary
+        assertThat(oldPrimaryAddress.isPrimary()).isFalse();
         assertThat(otherAddress.isPrimary()).isFalse();
-        verify(userAddressRepository, times(1)).save(any(UserAddress.class));
     }
 
     @Test
-    @DisplayName("주소 목록 조회")
-    void getUserAddresses() {
+    @DisplayName("SAVE-SUCCESS-003: 일반 주소 저장 시, 기존 기본 주소에 영향 없음")
+    void saveAddress_nonPrimaryShouldRemainNonPrimaryIfPrimaryExists() {
         // given
-        when(droniUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser))
-                .thenReturn(List.of(UserAddress.builder().build(), UserAddress.builder().build()));
+        AddressSaveRequest saveRequest = createSaveRequest(false);
+        UserAddress existingPrimaryAddress = UserAddress.builder().user(testUser).isPrimary(true).build();
+
+        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(existingPrimaryAddress));
 
         // when
-        List<UserAddress> userAddresses = addressService.getUserAddresses(1L);
+        addressService.saveAddress(userId, saveRequest);
 
         // then
-        assertThat(userAddresses).hasSize(2);
+        ArgumentCaptor<UserAddress> addressCaptor = ArgumentCaptor.forClass(UserAddress.class);
+        verify(userAddressRepository).save(addressCaptor.capture());
+        UserAddress newAddress = addressCaptor.getValue();
+
+        assertThat(newAddress.isPrimary()).isFalse();
+        assertThat(existingPrimaryAddress.isPrimary()).isTrue();
     }
 
     @Test
-    @DisplayName("주소 저장 - 사용자를 찾을 수 없으면 DroniNotFoundException 발생")
-    void saveAddress_throwsDroniNotFoundException_whenUserNotFound() {
+    @DisplayName("SAVE-SUCCESS-004: 기존에 기본 주소 없을 시, 새 주소는 기본 주소로 자동 설정")
+    void saveAddress_shouldBecomePrimaryIfNoPrimaryExists() {
         // given
-        long userId = 1L;
+        AddressSaveRequest saveRequest = createSaveRequest(false);
+        UserAddress nonPrimaryAddress = UserAddress.builder().user(testUser).isPrimary(false).build();
+
+        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(nonPrimaryAddress));
+
+        // when
+        addressService.saveAddress(userId, saveRequest);
+
+        // then
+        ArgumentCaptor<UserAddress> addressCaptor = ArgumentCaptor.forClass(UserAddress.class);
+        verify(userAddressRepository).save(addressCaptor.capture());
+        UserAddress newAddress = addressCaptor.getValue();
+
+        assertThat(newAddress.isPrimary()).isTrue();
+        assertThat(nonPrimaryAddress.isPrimary()).isFalse();
+    }
+
+    @Test
+    @DisplayName("SAVE-FAIL-001: 존재하지 않는 사용자로 주소 저장 시, 예외 발생")
+    void saveAddress_shouldThrowException_whenUserNotFound() {
+        // given
         AddressSaveRequest saveRequest = createSaveRequest(true);
         when(droniUserRepository.findById(userId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(DroniNotFoundException.class, () -> {
-            addressService.saveAddress(userId, saveRequest);
-        });
-
+        assertThrows(DroniNotFoundException.class, () -> addressService.saveAddress(userId, saveRequest));
         verify(userAddressRepository, never()).save(any(UserAddress.class));
     }
 
     @Test
-    @DisplayName("주소 목록 조회 - 사용자를 찾을 수 없으면 DroniNotFoundException 발생")
-    void getUserAddresses_throwsDroniNotFoundException_whenUserNotFound() {
+    @DisplayName("GET-SUCCESS-001: 주소 목록 조회 성공")
+    void getUserAddresses_shouldReturnAddressList() {
         // given
-        long userId = 1L;
+        List<UserAddress> expectedAddresses = List.of(
+            UserAddress.builder().build(),
+            UserAddress.builder().build()
+        );
+        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser)).thenReturn(expectedAddresses);
+
+        // when
+        List<UserAddress> actualAddresses = addressService.getUserAddresses(userId);
+
+        // then
+        assertThat(actualAddresses).hasSize(2);
+        assertThat(actualAddresses).isEqualTo(expectedAddresses);
+    }
+
+    @Test
+    @DisplayName("GET-SUCCESS-002: 주소가 없는 사용자의 목록 조회 시, 빈 리스트 반환")
+    void getUserAddresses_shouldReturnEmptyList_whenNoAddresses() {
+        // given
+        when(droniUserRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(userAddressRepository.findByUser(testUser)).thenReturn(Collections.emptyList());
+
+        // when
+        List<UserAddress> userAddresses = addressService.getUserAddresses(userId);
+
+        // then
+        assertThat(userAddresses).isNotNull();
+        assertThat(userAddresses).isEmpty();
+    }
+
+    @Test
+    @DisplayName("GET-FAIL-001: 존재하지 않는 사용자로 주소 목록 조회 시, 예외 발생")
+    void getUserAddresses_shouldThrowException_whenUserNotFound() {
+        // given
         when(droniUserRepository.findById(userId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(DroniNotFoundException.class, () -> {
-            addressService.getUserAddresses(userId);
-        });
-
+        assertThrows(DroniNotFoundException.class, () -> addressService.getUserAddresses(userId));
         verify(userAddressRepository, never()).findByUser(any(DroniUser.class));
     }
 }

--- a/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
+++ b/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
@@ -15,8 +15,6 @@ import droni.backend.api.droniuser.entity.DroniUser;
 import droni.backend.api.droniuser.repository.DroniUserRepository;
 import droni.backend.global.exception.DroniNotFoundException;
 import droni.backend.oauth2.service.OAuth2UserPrincipal;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -69,7 +67,8 @@ class AddressServiceTest {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
         when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser)).thenReturn(Collections.emptyList());
+        when(userAddressRepository.existsByUser(testUser)).thenReturn(false);
+        when(userAddressRepository.findByUserAndPrimaryTrue(testUser)).thenReturn(Optional.empty());
 
         // when
         addressService.saveAddress(testUserPrincipal, saveRequest);
@@ -96,19 +95,11 @@ class AddressServiceTest {
                         "서울시",
                         "강남구",
                         testUser);
-        UserAddress otherAddress =
-                UserAddress.create(
-                        "other",
-                        false,
-                        "김철수",
-                        "010-3333-4444",
-                        "부산시",
-                        "해운대구",
-                        testUser);
 
         when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser))
-                .thenReturn(List.of(oldPrimaryAddress, otherAddress));
+        when(userAddressRepository.existsByUser(testUser)).thenReturn(true);
+        when(userAddressRepository.findByUserAndPrimaryTrue(testUser))
+                .thenReturn(Optional.of(oldPrimaryAddress));
 
         // when
         addressService.saveAddress(testUserPrincipal, saveRequest);
@@ -120,7 +111,6 @@ class AddressServiceTest {
 
         assertThat(newAddress.isPrimary()).isTrue();
         assertThat(oldPrimaryAddress.isPrimary()).isFalse();
-        assertThat(otherAddress.isPrimary()).isFalse();
     }
 
     @Test
@@ -139,8 +129,9 @@ class AddressServiceTest {
                         testUser);
 
         when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser))
-                .thenReturn(List.of(existingPrimaryAddress));
+        when(userAddressRepository.existsByUser(testUser)).thenReturn(true);
+        when(userAddressRepository.findByUserAndPrimaryTrue(testUser))
+                .thenReturn(Optional.of(existingPrimaryAddress));
 
         // when
         addressService.saveAddress(testUserPrincipal, saveRequest);
@@ -159,19 +150,10 @@ class AddressServiceTest {
     void saveAddress_shouldBecomePrimaryIfNoPrimaryExists() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
-        UserAddress nonPrimaryAddress =
-                UserAddress.create(
-                        "일반주소",
-                        false,
-                        "김철수",
-                        "010-9876-5432",
-                        "부산시",
-                        "해운대구",
-                        testUser);
-
         when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser))
-                .thenReturn(List.of(nonPrimaryAddress));
+        when(userAddressRepository.existsByUser(testUser)).thenReturn(true);
+        when(userAddressRepository.findByUserAndPrimaryTrue(testUser))
+                .thenReturn(Optional.empty());
 
         // when
         addressService.saveAddress(testUserPrincipal, saveRequest);
@@ -182,7 +164,6 @@ class AddressServiceTest {
         UserAddress newAddress = addressCaptor.getValue();
 
         assertThat(newAddress.isPrimary()).isTrue();
-        assertThat(nonPrimaryAddress.isPrimary()).isFalse();
     }
 
     @Test

--- a/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
+++ b/src/test/java/droni/backend/api/address/service/AddressServiceTest.java
@@ -1,5 +1,13 @@
 package droni.backend.api.address.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import droni.backend.api.address.dto.AddressSaveRequest;
 import droni.backend.api.address.entity.UserAddress;
 import droni.backend.api.address.repository.UserAddressRepository;
@@ -7,6 +15,9 @@ import droni.backend.api.droniuser.entity.DroniUser;
 import droni.backend.api.droniuser.repository.DroniUserRepository;
 import droni.backend.global.exception.DroniNotFoundException;
 import droni.backend.oauth2.service.OAuth2UserPrincipal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,15 +26,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AddressServiceTest {
@@ -55,17 +57,14 @@ class AddressServiceTest {
 
     @BeforeEach
     void setUp() {
-        testUser = DroniUser.builder()
-                .userId(userId)
-                .oauthId(oauthId)
-                .build();
+        testUser = DroniUser.builder().userId(userId).oauthId(oauthId).build();
 
         testUserPrincipal = mock(OAuth2UserPrincipal.class);
         when(testUserPrincipal.getOAuth2Id()).thenReturn(oauthId);
     }
 
     @Test
-    @DisplayName("SAVE-SUCCESS-001: 첫 주소 저장 시, 요청과 무관하게 기본 주소로 자동 설정")
+    @DisplayName("첫 주소 저장 시 기본 주소로 자동 설정된다")
     void saveAddress_firstAddressShouldBePrimary() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
@@ -84,19 +83,32 @@ class AddressServiceTest {
     }
 
     @Test
-    @DisplayName("SAVE-SUCCESS-002: 새로운 기본 주소 저장 시, 기존 기본 주소는 해제")
+    @DisplayName("새로운 기본 주소 저장 시 기존 기본 주소가 해제된다")
     void saveAddress_newPrimaryShouldDemoteOldPrimary() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(true);
-        UserAddress oldPrimaryAddress = UserAddress.create(
-                "oldPrimary", true, "홍길동", "010-1111-2222", "서울시", "강남구", testUser
-        );
-        UserAddress otherAddress = UserAddress.create(
-                "other", false, "김철수", "010-3333-4444", "부산시", "해운대구", testUser
-        );
+        UserAddress oldPrimaryAddress =
+                UserAddress.create(
+                        "oldPrimary",
+                        true,
+                        "홍길동",
+                        "010-1111-2222",
+                        "서울시",
+                        "강남구",
+                        testUser);
+        UserAddress otherAddress =
+                UserAddress.create(
+                        "other",
+                        false,
+                        "김철수",
+                        "010-3333-4444",
+                        "부산시",
+                        "해운대구",
+                        testUser);
 
         when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(oldPrimaryAddress, otherAddress));
+        when(userAddressRepository.findByUser(testUser))
+                .thenReturn(List.of(oldPrimaryAddress, otherAddress));
 
         // when
         addressService.saveAddress(testUserPrincipal, saveRequest);
@@ -112,16 +124,23 @@ class AddressServiceTest {
     }
 
     @Test
-    @DisplayName("SAVE-SUCCESS-003: 일반 주소 저장 시, 기존 기본 주소에 영향 없음")
+    @DisplayName("일반 주소 저장 시 기존 기본 주소에 영향을 주지 않는다")
     void saveAddress_nonPrimaryShouldRemainNonPrimaryIfPrimaryExists() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
-        UserAddress existingPrimaryAddress = UserAddress.create(
-                "기본주소", true, "홍길동", "010-1234-5678", "서울시", "강남구", testUser
-        );
+        UserAddress existingPrimaryAddress =
+                UserAddress.create(
+                        "기본주소",
+                        true,
+                        "홍길동",
+                        "010-1234-5678",
+                        "서울시",
+                        "강남구",
+                        testUser);
 
         when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(existingPrimaryAddress));
+        when(userAddressRepository.findByUser(testUser))
+                .thenReturn(List.of(existingPrimaryAddress));
 
         // when
         addressService.saveAddress(testUserPrincipal, saveRequest);
@@ -136,16 +155,23 @@ class AddressServiceTest {
     }
 
     @Test
-    @DisplayName("SAVE-SUCCESS-004: 기존에 기본 주소 없을 시, 새 주소는 기본 주소로 자동 설정")
+    @DisplayName("기존에 기본 주소가 없으면 새 주소가 기본 주소로 자동 설정된다")
     void saveAddress_shouldBecomePrimaryIfNoPrimaryExists() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(false);
-        UserAddress nonPrimaryAddress = UserAddress.create(
-                "일반주소", false, "김철수", "010-9876-5432", "부산시", "해운대구", testUser
-        );
+        UserAddress nonPrimaryAddress =
+                UserAddress.create(
+                        "일반주소",
+                        false,
+                        "김철수",
+                        "010-9876-5432",
+                        "부산시",
+                        "해운대구",
+                        testUser);
 
         when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser)).thenReturn(List.of(nonPrimaryAddress));
+        when(userAddressRepository.findByUser(testUser))
+                .thenReturn(List.of(nonPrimaryAddress));
 
         // when
         addressService.saveAddress(testUserPrincipal, saveRequest);
@@ -160,53 +186,20 @@ class AddressServiceTest {
     }
 
     @Test
-    @DisplayName("SAVE-FAIL-001: 존재하지 않는 사용자로 주소 저장 시, 예외 발생")
+    @DisplayName("존재하지 않는 사용자로 주소 저장 시 예외가 발생한다")
     void saveAddress_shouldThrowException_whenUserNotFound() {
         // given
         AddressSaveRequest saveRequest = createSaveRequest(true);
         when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(DroniNotFoundException.class, () -> addressService.saveAddress(testUserPrincipal, saveRequest));
+        assertThrows(
+                DroniNotFoundException.class, () -> addressService.saveAddress(testUserPrincipal, saveRequest));
         verify(userAddressRepository, never()).save(any(UserAddress.class));
     }
 
     @Test
-    @DisplayName("GET-SUCCESS-001: 주소 목록 조회 성공")
-    void getUserAddresses_shouldReturnAddressList() {
-        // given
-        List<UserAddress> expectedAddresses = List.of(
-                UserAddress.create("주소1", true, "홍길동", "010-1234-5678", "서울시", "강남구", testUser),
-                UserAddress.create("주소2", false, "김철수", "010-9876-5432", "부산시", "해운대구", testUser)
-        );
-        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser)).thenReturn(expectedAddresses);
-
-        // when
-        List<UserAddress> actualAddresses = addressService.getUserAddresses(testUserPrincipal);
-
-        // then
-        assertThat(actualAddresses).hasSize(2);
-        assertThat(actualAddresses).isEqualTo(expectedAddresses);
-    }
-
-    @Test
-    @DisplayName("GET-SUCCESS-002: 주소가 없는 사용자의 목록 조회 시, 빈 리스트 반환")
-    void getUserAddresses_shouldReturnEmptyList_whenNoAddresses() {
-        // given
-        when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.of(testUser));
-        when(userAddressRepository.findByUser(testUser)).thenReturn(Collections.emptyList());
-
-        // when
-        List<UserAddress> userAddresses = addressService.getUserAddresses(testUserPrincipal);
-
-        // then
-        assertThat(userAddresses).isNotNull();
-        assertThat(userAddresses).isEmpty();
-    }
-
-    @Test
-    @DisplayName("GET-FAIL-001: 존재하지 않는 사용자로 주소 목록 조회 시, 예외 발생")
+    @DisplayName("존재하지 않는 사용자로 주소 목록 조회 시 예외가 발생한다")
     void getUserAddresses_shouldThrowException_whenUserNotFound() {
         // given
         when(droniUserRepository.findByOauthId(oauthId)).thenReturn(Optional.empty());


### PR DESCRIPTION
#### 개요

- 마이페이지 > 설정 > 주소지 관리 기능을 위한 백엔드 API 및 도메인 구조를 추가합니다.
- 사용자는 여러 주소지를 가질 수 있으며, 한 개 이상의 주소지가 있을 경우 반드시 하나의 기본 주소지를 갖도록 설계하였습니다.
- 주소지 정보는 이름, 연락처, 주소명, 기본 주소지 여부, 주소1(기본), 주소2(상세)로 구성됩니다.
- 확장성과 향후 기능 추가를 고려하여 테이블 및 엔티티를 설계하였습니다.

---

#### 주요 변경사항

1. **Address 도메인 신규 추가**
    
   - **`AddressController.java`**: 주소지 생성 (`POST /api/v1/addresses`) 및 목록 조회 (`GET /api/v1/addresses`) API를 제공합니다.
   - **`AddressSaveRequest.java`**, **`AddressResponse.java`**: 주소지 저장 요청/응답 DTO입니다.
   - **`UserAddress.java`**: 주소지 엔티티로 JPA Auditing이 적용되어 `createdAt` 및 `updatedAt` 필드가 포함됩니다. 또한, `user_address` 테이블에 `user_id` 컬럼을 이용한 인덱스(`idx_user_id`)가 추가되었습니다1.
   - **`UserAddressRepository.java`**: 유저별 주소지 목록 조회 (`findByUser`)를 지원합니다2.
   - **`AddressService.java`**: 주소지 저장 및 조회 관련 비즈니스 로직을 처리합니다.

2. **DroniUserRepository 확장**
    
   - `findByOauthId` 메서드를 추가하여 OAuth2 principal 기반으로 유저를 조회하는 기능을 지원합니다.

3. **DroniUser 알림 설정 필드 변경**
    
   - 기존의 `notificationEnabled`와 `marketingEnabled` 필드가 더 세분화된 알림 설정 필드로 변경되었습니다.
   - **`appPushNotificationEnabled`**
   - **`kakaoTalkNotificationEnabled`**
   - **`chatNotificationEnabled`**
   - **`estimateBidNotificationEnabled`**

4. **테스트 코드 추가**

   - **`AddressControllerTest`**, **`AddressServiceTest`**: API 및 서비스 레이어 단위 테스트가 추가되었습니다.
   - 기본 주소지 정책, 저장/조회 케이스를 검증하는 테스트가 포함됩니다.
   - 인증 정보가 없는 경우 404 Not Found 예외를 반환하는 테스트가 추가되었습니다.

5. **보안 테스트 의존성 추가**

   - `build.gradle` 파일에 **`org.springframework.security:spring-security-test`** 의존성이 추가되었습니다.

---

#### 상세 구현 및 정책

- **기본 주소지 정책**
    
    - 첫 주소지는 무조건 기본 주소지로 저장됩니다.
    - 새 주소지가 기본으로 지정되면 기존 기본 주소지는 해제됩니다.
    - 기본 주소지가 없는 상태에서 새 주소지가 기본이 아니면 자동으로 기본 주소지로 승격됩니다.

- **확장성**
    
    - `UserAddress` 엔티티에 JPA Auditing 필드(`createdAt`, `updatedAt`) 포함되어 있습니다.
    - 추후 주소지 삭제, 수정, 기타 정보 추가가 용이하도록 설계되었습니다.

---

#### API 명세

- **POST `/api/v1/addresses`**
    
    - 주소지 저장 (인증 필요).
    - Request: `AddressSaveRequest`
    - Response: `AddressResponse`

- **GET `/api/v1/addresses`**
    
    - 유저의 주소지 목록 조회 (인증 필요).
    - Response: `List<AddressResponse>`

---

#### 테스트

- 서비스 및 컨트롤러 단위테스트 포함.
- 기본 주소지 정책, 저장/조회 정상동작 검증.
- 존재하지 않는 사용자로 요청 시 예외 처리 검증.

---

#### 관련 이슈

- #45

---

#### 변경 파일

- `build.gradle`
- `AddressController.java`
- `AddressResponse.java`    
- `AddressSaveRequest.java`
- `UserAddress.java`
- `UserAddressRepository.java`
- `AddressService.java`
- `DroniUser.java`
- `DroniUserQuerydslRepository.java`
- `DroniUserQuerydslRepositoryImpl.java`
- `OAuth2UserPrincipal.java`
- `AddressControllerTest.java`
- `AddressServiceTest.java`
- `DroniUserRepositoryTest.java`
- `test-expert.sql`
- `test-user-set.sql`

---

리뷰 부탁드립니다. 🙇‍♂️